### PR TITLE
Fix 'package' gulp task and bump version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.7.7
+- Re-release to fix a faulty extension zip we uploaded with 0.7.6
+
 # 0.7.6
 - Removed all functionality of the What's Next tab
 - Adjusted the colors for the Daily and Monthly labels, as they changed on GitHub

--- a/gulp/tasks/zip.js
+++ b/gulp/tasks/zip.js
@@ -6,7 +6,7 @@ var zip = require('gulp-zip');
 
 module.exports = function(options) {
   return function() {
-      return gulp.src('dist/*')
+      return gulp.src('dist/**/*')
         .pipe(plumber({
           errorHandler: require('../error.beep')
         }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "A Chrome Extenstion for Kernel Schedule",
   "main": "index.js",
   "author": "Tim Golen <tim@golen.net>",


### PR DESCRIPTION
@tgolen 

This fixes the `npm run package` task creating a flawless `dist.zip` file again.