### PR TITLE
Fix class name for getting username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.8.5
+- Fixed a bug with getting the GH username.
+
 # 0.8.4
 - Updating Pull Requests to Review Requests and ensuring that an unassigned PR will still show up so it doesn't get lost
 

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/lib/js/lib/api.js
+++ b/lib/js/lib/api.js
@@ -13,7 +13,7 @@ const baseUrl = 'https://api.github.com';
  * @returns {String}
  */
 function getCurrentUser() {
-  return $('.user-nav .avatar').attr('alt').replace('@', '');
+  return $('.Header-link .avatar').attr('alt').replace('@', '');
 }
 
 function parse_link_header(header) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A Chrome Extenstion for Kernel Schedule",
   "main": "index.js",
   "author": "Tim Golen <tim@golen.net>",


### PR DESCRIPTION
KSv2 was breaking because Github changed a class name for their header and we were getting null for the username.

Fixes https://github.com/Expensify/Expensify/issues/102155

# Test
1. Load up KSv2, confirm it works.