### PR TITLE
Filter PR Reviews based on URL

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/lib/js/action/pull.reviewing.js
+++ b/lib/js/action/pull.reviewing.js
@@ -14,10 +14,15 @@ class Action {
     this.dispatch();
 
     API.getPullsReviewing((err, data) => {
+      var filtered;
       if (err) {
         return this.actions.failed(err);
       }
-      this.actions.update(data);
+      filtered = data.filter((pr) => {
+        // Filter out non expensify prs
+        return pr.url.includes('Expensify');
+      });
+      this.actions.update(filtered);
     });
   }
 }

--- a/lib/js/lib/api.js
+++ b/lib/js/lib/api.js
@@ -730,7 +730,6 @@ function getPullsReviewing(cb) {
         if (!pr.assignee) {
           return true;
         }
-
         return pr.assignee.login !== getCurrentUser();
       })
       .sortBy('userIsFinishedReviewing')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A Chrome Extenstion for Kernel Schedule",
   "main": "index.js",
   "author": "Tim Golen <tim@golen.net>",


### PR DESCRIPTION
This filters PR reviews based on if they have `Expensify` in the URL

After getting sick of seeing 6 PR reviews that open source maintainers have _yet_ to merge after 3 months, I finally took the time to filter them. 

If there is a better way / place to do this filtering let me know.

I don't have access to the Extension Store to update this, so after merging feel free to upload this 🙇 