### PR TITLE
Fix bugs with displaying Travis status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#0.9.11
+- Fix bug displaying Travis status for builds that are not yet finished
+- Better formatting for Travis status that contains underscores
+- Make sure we don't display blank Travis status
+
 #0.9.10
 - Switch from basic auth to token auth (and ease in the change so folks don't have to re-auth)
 - Restore functionality that displays Travis status next to pull requests

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/lib/js/component/list-item/pull.js
+++ b/lib/js/component/list-item/pull.js
@@ -116,7 +116,7 @@ module.exports = React.createClass({
             </span>
           ) : null}
 
-          {this.props.data.pr.status && this.props.data.pr.status.length
+          {this.props.data.pr.status && this.props.data.pr.status.length && this.props.data.pr.status[0].state
             ? (
               <span className={`travis-status ${this.props.data.pr.status[0].state}`}>
            Travis: {this.props.data.pr.status[0].state},

--- a/lib/js/lib/api.js
+++ b/lib/js/lib/api.js
@@ -344,7 +344,10 @@ function getPullsByType(type, cb, getReviews) {
               } else {
                 // Check-runs endpoint uses .conclusion instead of .state - map it
                 // back to .state in order not to change the view
-                item.pr.status = check_runs.map(status => Object.assign({state: status.conclusion}, status));
+                item.pr.status = check_runs.map(status => {
+                  const state = ((status.conclusion ? status.conclusion : status.status) || '').replace(/_/g, ' ');
+                  return Object.assign({state}, status);
+                });
                 return maybeGetReviews();
               }
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "A Chrome Extenstion for Kernel Schedule",
   "main": "index.js",
   "author": "Tim Golen <tim@golen.net>",


### PR DESCRIPTION
* Don't show blank status
* Better formatting if status name contains underscores
* Handle case where build is not finished (no "conclusion" reached)

Also bump version and update changelog

<img width="1011" alt="Screen Shot 2020-05-21 at 9 35 41 AM" src="https://user-images.githubusercontent.com/1058475/82582809-71a76300-9b47-11ea-85cf-e58c4c777434.png">
