### PR TITLE
Always display mergeability status

### DIFF
--- a/lib/js/component/list-item/pull.js
+++ b/lib/js/component/list-item/pull.js
@@ -86,7 +86,7 @@ module.exports = React.createClass({
     case 'unknown':
     default:
       mergeability = 'Mergeability Unknown';
-      console.log(this.props.data.pr);
+      console.log('Unable to determine mergeable state of this PR', this.props.data.pr);
     }
 
     // If we are showing the assignee, we need to figure which template to display


### PR DESCRIPTION
We added a comma after the Travis status because we expect mergeability status to always show, but if we hit an edge case, it wasn't showing. So let's always show something.

@tgolen I wasn't able to reproduce the edge cases from this morning. So instead, I'm adding this change so that we:

1. Always show something for mergeability status
1. If we get `unknown` back from GitHub, log something to the console, so if somebody thinks to ask about it, we have some debugging information.