### PR TITLE
Remove support for the old GitHub UI

### DIFF
--- a/lib/js/lib/pages/github/all.js
+++ b/lib/js/lib/pages/github/all.js
@@ -7,9 +7,7 @@
 let $ = require('jquery');
 let Base = require('./_base');
 let k2Button = require('../../../template/button.github.k2.html');
-let k2ButtonNew = require('../../../template/button.github.k2.new.html');
 let whatsnextButton = require('../../../template/button.github.whatsnext.html');
-let whatsnextButtonNew = require('../../../template/button.github.whatsnext.new.html');
 
 module.exports = function() {
   let AllPages = new Base();
@@ -26,28 +24,16 @@ module.exports = function() {
 
     // Insert the what's next button right after the pull request button in the navigation
     // navigation if it's there. Also make sure to not show it multiple times
-    if (!$('.reponav-item.k2-whatsnext').length) {
-      $('.reponav-item[data-selected-links*="repo_pulls"]')
-        .after(whatsnextButton({url: currentUrl}));
-    }
-
-    // Also try inserting what's next button with the new UI
     if (!$('nav.js-repo-nav li.k2-whatsnext').length) {
       $('nav.js-repo-nav *[data-selected-links*="repo_pulls"]')
-        .parent().after(whatsnextButtonNew({url: currentUrl}));
+        .parent().after(whatsnextButton({url: currentUrl}));
     }
 
     // Insert the kernel button right after the pull request button in the
     // navigation if it's there. Also make sure to not show it multiple times
-    if (!$('.reponav-item.k2-extension').length) {
-      $('.reponav-item[data-selected-links*="repo_pulls"]')
-        .after(k2Button({url: currentUrl}));
-    }
-
-    // Also try inserting the kernel button with the new UI
     if (!$('nav.js-repo-nav li.k2-extension').length) {
       $('nav.js-repo-nav *[data-selected-links*="repo_pulls"]')
-        .parent().after(k2ButtonNew({url: currentUrl}));
+        .parent().after(k2Button({url: currentUrl}));
     }
   };
 

--- a/lib/js/lib/pages/github/main.js
+++ b/lib/js/lib/pages/github/main.js
@@ -24,17 +24,11 @@ module.exports = function() {
     // Only do stuff if we are on the kernal page
     if (window.location.hash.search('#k2') === 0) {
       // Deselect whatever button is currently selected
-      $('.reponav-item.selected').removeClass('selected');
-
-      // Deselect currently-selected button in new UI
       const selected = $('.js-selected-navigation-item.selected');
       selected.removeClass('selected');
       selected.removeAttr('aria-current');
 
       // Select our k2 button
-      $('.reponav-item.k2-extension').addClass('selected');
-
-      // Select our K2 button in new UI
       const k2tab = $('.js-selected-navigation-item.k2-extension');
       k2tab.addClass('selected');
       k2tab.attr('aria-current', 'page');
@@ -48,17 +42,11 @@ module.exports = function() {
 
     if (window.location.hash.search('#whatsnext') === 0) {
       // Deselect the code button
-      $('.reponav-item.selected').removeClass('selected');
-
-      // Deselect currently-selected button in new UI
       const selected = $('.js-selected-navigation-item.selected');
       selected.removeClass('selected');
       selected.removeAttr('aria-current');
 
       // Select our what's next button
-      $('.reponav-item.k2-whatsnext').addClass('selected');
-
-      // Select our WN button in new UI
       const wnTab = $('.js-selected-navigation-item.k2-whatsnext');
       wnTab.addClass('selected');
       wnTab.attr('aria-current', 'page');

--- a/lib/js/template/button.github.k2.html
+++ b/lib/js/template/button.github.k2.html
@@ -1,3 +1,5 @@
-<a href="<%= url %>#k2" class="js-selected-navigation-item reponav-item k2-extension">
-    K2
-</a>
+<li class="d-flex k2-extension">
+    <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item k2-extension" data-tab-item="k2-extension-tab" data-selected-links="k2_extension /Expensify/Expensify" href="<%= url %>#k2">
+        <span data-content="K2">K2</span>
+    </a>
+</li>

--- a/lib/js/template/button.github.k2.new.html
+++ b/lib/js/template/button.github.k2.new.html
@@ -1,5 +1,0 @@
-<li class="d-flex k2-extension">
-    <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item k2-extension" data-tab-item="k2-extension-tab" data-selected-links="k2_extension /Expensify/Expensify" href="<%= url %>#k2">
-        <span data-content="K2">K2</span>
-    </a>
-</li>

--- a/lib/js/template/button.github.whatsnext.html
+++ b/lib/js/template/button.github.whatsnext.html
@@ -1,3 +1,5 @@
-<a href="<%= url %>#whatsnext" class="js-selected-navigation-item reponav-item k2-whatsnext">
-    WN
-</a>
+<li class="d-flex k2-whatsnext">
+    <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item k2-whatsnext" data-tab-item="k2-whatsnext-tab" data-selected-links="k2_whatsnext /Expensify/Expensify" href="<%= url %>#whatsnext">
+        <span data-content="WN">WN</span>
+    </a>
+</li>

--- a/lib/js/template/button.github.whatsnext.new.html
+++ b/lib/js/template/button.github.whatsnext.new.html
@@ -1,5 +1,0 @@
-<li class="d-flex k2-whatsnext">
-    <a class="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item k2-whatsnext" data-tab-item="k2-whatsnext-tab" data-selected-links="k2_whatsnext /Expensify/Expensify" href="<%= url %>#whatsnext">
-        <span data-content="WN">WN</span>
-    </a>
-</li>


### PR DESCRIPTION
Looks like the change is permanent based on https://github.blog/changelog/2020-06-23-design-updates-to-repositories-and-github-ui/ and https://expensify.slack.com/archives/C03TQ48KC/p1592950785339900

Follow up to https://github.com/Expensify/k2-chrome-extension/pull/42

Ran `npm run build` and refreshed at `chrome://extensions`. Here is a screenshot to confirm it still works:

<img width="1904" alt="Screen Shot 2020-06-23 at 4 44 42 PM" src="https://user-images.githubusercontent.com/1058475/85478350-e91a4900-b570-11ea-8d90-6279d5faf920.png">
