### PR TITLE
Bring to the issue template selection when creating a new issue

### DIFF
--- a/lib/js/module/dashboard/list.issues.js
+++ b/lib/js/module/dashboard/list.issues.js
@@ -42,7 +42,7 @@ module.exports = React.createClass({
           <button onClick={this.signOut} className="btn tooltipped tooltipped-sw" aria-label="Sign Out">Sign Out</button>
           <br />
           <br />
-          <a className="btn btn-primary" aria-label="New Issue" href="https://github.com/Expensify/Expensify/issues/new/" target="_blank">New Issue</a>
+          <a className="btn btn-primary" aria-label="New Issue" href="https://github.com/Expensify/Expensify/issues/new/choose" target="_blank">New Issue</a>
 
           <br />
           <div className="issue reviewing">Under Review</div>


### PR DESCRIPTION
When clicking the "New Issue" button in the K2 dashboard, it brings us to an empty issue form. We have a ton of great issue templates, we should make use of them so the button should bring us to the page where we can select them. 