### PR TITLE
Add conditional for nodejs desired version for Ubuntu 20.04

### DIFF
--- a/tools/checkRuntimeVersions.sh
+++ b/tools/checkRuntimeVersions.sh
@@ -2,9 +2,16 @@
 
 installedNodeVersion=$(node -v)
 installedNpmVersion=$(npm -v)
-
 desiredNodeVersion="v14.10.0"
 desiredNpmVersion="6.14.8"
+
+# While we're transitioning from Ubuntu 16.04 to 20.04, we need to conditionally override this variable
+# depending on which Ubuntu release we're running this script on.
+if [[ "$(uname)" == "Linux" ]] ; then
+    if [[ "$(lsb_release -rs)" == "20.04" ]] ; then
+       desiredNodeVersion="v14.15.0"
+    fi
+fi
 
 if [ "$installedNodeVersion" != "$desiredNodeVersion" ]
 then


### PR DESCRIPTION
For the transitional period between Ubuntu 16.04 and 20.04, we need a conditional to define the desired nodejs version depending on the Ubuntu release this script is running on. This should enable Jenkins on 20.04 to build packages.

Part of Expensify/Expensify#137410