### PR TITLE
Gray "Take Home Challenge Sent" labelled issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#0.9.21
+ - Grey issues with "Take Home Challenge Sent" label since there is nothing actionable by the engineer
+
 #0.9.20
  - Surface `Expensify/Expensify.cash` issues in the dashboard
 

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/lib/css/content.scss
+++ b/lib/css/content.scss
@@ -187,6 +187,7 @@ $color-dark-yellow: #DAA520;
   }
   // define before overdue so overdue issues will still appears red, since
   // issue erosion still happens for "held issues"
+  &.challenge-sent,
   &.hold {
     color: darken($color-neutral-light, 20%) !important;
     .issue-link {

--- a/lib/js/component/list-item/issue.js
+++ b/lib/js/component/list-item/issue.js
@@ -28,6 +28,7 @@ module.exports = React.createClass({
     this.isOverdue = _(this.props.data.labels).findWhere({name: 'Overdue'});
     this.isWaitingOnCustomer = _(this.props.data.labels).findWhere({name: 'Waiting for customer'}) ? ' waiting-for-customer' : '';
     this.isHeld = this.props.data.title.toLowerCase().indexOf('[hold') > -1 ? ' hold' : '';
+    this.isChallengeSent = _(this.props.data.labels).findWhere({name: 'Take Home Challenge Sent'}) ? ' challenge-sent' : '';
     this.isUnderReview = _(this.props.data.labels).find(function(label) {
       return label.name.toLowerCase() === 'reviewing';
     });
@@ -45,7 +46,7 @@ module.exports = React.createClass({
       className += ' overdue';
     }
 
-    return className + this.isPlanning + this.isWaitingOnCustomer + this.isHeld;
+    return className + this.isPlanning + this.isWaitingOnCustomer + this.isHeld + this.isChallengeSent;
   },
   render: function() {
     this.parseIssue();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-chrome-extension",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "A Chrome Extenstion for Kernel Schedule",
   "main": "index.js",
   "author": "Tim Golen <tim@golen.net>",


### PR DESCRIPTION
Helps with https://github.com/Expensify/Expensify/issues/159699

Tested this by loading locally and confirming my test issue and the job application issues that have the label `Take Home Challenge Sent` are grayed out,
![image](https://user-images.githubusercontent.com/14356145/115076813-f0b92e80-9eb1-11eb-8b0c-72651631e166.png)
