### PR TITLE
Enable . in regex so Expensify.cash gh urls are recognized

### DIFF
--- a/lib/js/lib/pages/github/createpr.js
+++ b/lib/js/lib/pages/github/createpr.js
@@ -36,7 +36,7 @@ module.exports = function () {
   /**
    * Regex for the create new PR page
    */
-  CreatePrPage.urlPath = '^(/[\\w-]+/[\\w-]+/compare/.*)$';
+  CreatePrPage.urlPath = '^(/[\\w-]+/[\\w-.]+/compare/.*)$';
 
   /**
    * Runs on page load, adds qa guidelines content and event listener to show/hide the guidelines

--- a/lib/js/lib/pages/github/issuenew.js
+++ b/lib/js/lib/pages/github/issuenew.js
@@ -13,7 +13,7 @@ module.exports = function () {
   /**
    * Add buttons to the page and setup the event handler
    */
-  IssueNewPage.urlPath = '^(/[\\w-]+/[\\w-]+/issues/new)$';
+  IssueNewPage.urlPath = '^(/[\\w-]+/[\\w-.]+/issues/new)$';
 
   /**
    * Add buttons to the page and setup the event handler

--- a/lib/js/lib/pages/github/main.js
+++ b/lib/js/lib/pages/github/main.js
@@ -15,7 +15,7 @@ module.exports = function() {
   /**
    * Add buttons to the page and setup the event handler
    */
-  MainPage.urlPath = '^(/[\\w-]+/[\\w-]+/?)$';
+  MainPage.urlPath = '^(/[\\w-]+/[\\w-.]+/?)$';
 
   /**
    * Add buttons to the page and setup the event handler

--- a/lib/js/lib/pages/github/pr.js
+++ b/lib/js/lib/pages/github/pr.js
@@ -103,7 +103,7 @@ module.exports = function () {
   /**
    * Add buttons to the page and setup the event handler
    */
-  PrPage.urlPath = '^(/[\\w-]+/[\\w-]+/pull/[0-9]+\/?(?:/commits)?(?:/files)?)$';
+  PrPage.urlPath = '^(/[\\w-]+/[\\w-.]+/pull/[0-9]+\/?(?:/commits)?(?:/files)?)$';
 
   /**
    * Add buttons to the page and setup the event handler


### PR DESCRIPTION
We realized [here in this slack thread](https://expensify.slack.com/archives/C03TME82F/p1623439993139000) that we are not applying the PR rules (specifically blocking HOLD PRs from being merged). So this adds `Expensify.cash` (in the full pathname `/Expensify/Expensify.cash/pull/12345`) as valid match for the RegEx.

I figured I'd also update the other pages (issuenew, main, createpr) that wouldn't recognize `Expensify.cash` in the meantime.