### PR TITLE
Make the access token form smaller

### DIFF
--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -27,6 +27,10 @@ $color-dark-yellow: #DAA520;
     padding: 0 180px;
 }
 
+.passwordform {
+    max-width: 1000px;
+}
+
 .k2-inactive {
   opacity: 0.2;
 }


### PR DESCRIPTION

#### Before:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/26260477/159325838-9c9e52f6-cec7-4459-a575-62cc7bd05dcd.png">

#### After:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/26260477/159373787-c2ed804b-187a-40f1-aa5a-9019c7d08667.png">

### Fixed Issues:
$ https://github.com/Expensify/Expensify/issues/202110

### Tests
1. If you have the extension installed already, remove it so you have to re-enter a personal access token
2. Load up the extension, see the form for adding your access token and make sure it looks like the screenshot above.
