### PR TITLE
Clarify publishing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ To publish a new version of this extension, you should follow these steps:
 1. Click on the **Package** tab.
 1. Click on **Upload New Package**, then choose the `dist.zip` file that was created earlier.
 1. Click on **Upload**
+1. On the **Store Listing** page, copy the new version notes from CHANGELOG.md into the description field and click **Save Draft**
 1. Back on the **Package** tab, verify that the new version number is shown for the _Draft Package_.
-1. Go to the **Store Listing** tag, and enter the new version notes in the **Description** field.
-1. Click **Save Draft**, then **Submit for review**.
+1. Click **Submit for review**.
 1. Make sure `Publish "K2 for GitHub" automatically after it has passed review` is checked, then hit **Submit for review**.
 1. Done!
 


### PR DESCRIPTION
Simply update the instructions to match how publishing actually works in practice. 

No release required!