### PR TITLE
Only lint (A)dded, (C)hanged, or (M)odified files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,4 @@ jobs:
                   max_attempts: 5
                   command: npm ci
 
-            - run: npx eslint --max-warnings=0 $(git diff --name-only origin/main '**/*.js' | xargs)
+            - run: npx eslint --max-warnings=0 $(git diff --diff-filter=ACM --name-only origin/main '**/*.js' | xargs)


### PR DESCRIPTION
Adds a diff filter for `ACM` which is (A)dded, (C)hanged, or (M)odified files.

Fixes https://github.com/Expensify/Expensify/issues/215712

## Tests:
1. Pull `tgolen-refactor-milestones` branch, verify lint fails
2. Merge this branch into it
3. Verify it now passes