### PR TITLE
Correctly bump up the version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.1.7
+- Display created PRs with no assignees in 'Your Pull Requests'
+
 #1.1.6
 - Grey out issues with 'Help wanted' label
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {


### PR DESCRIPTION
I forgot to bump up the version numbers here: https://github.com/Expensify/k2-extension/pull/118