### PR TITLE
Use assignee.login as key in ListItemIssue

### DIFF
--- a/src/js/component/list-item/ListItemIssue.js
+++ b/src/js/component/list-item/ListItemIssue.js
@@ -90,6 +90,7 @@ class ListItemIssue extends React.Component {
                                     aria-label={`${assignee.login}'s assigned issues`}
                                     href={`/Expensify/App/issues?q=assignee%3A${assignee.login}+is%3Aopen`}
                                     data-turbo-frame="repo-content-turbo-frame"
+                                    key={assignee.login}
                                 >
                                     <img
                                         className="from-avatar avatar-user"


### PR DESCRIPTION
cc @tgolen 

Found while testing https://github.com/Expensify/k2-extension/pull/135

## Test

1. Build the extension locally ([instructions](https://github.com/Expensify/k2-extension/blob/aab04a405cc5c8b96683910673946e87f2e8b537/README.md)) and load it in the browser
2. Open the dev console and verify the React warning is not shown anymore.

Before:
<img width="545" alt="Screenshot 2023-01-06 at 18 32 22" src="https://user-images.githubusercontent.com/6829422/211121991-0e6757c4-fb2d-40a0-9e38-f6fd0e9d61cb.png">

After:
<img width="1511" alt="Screenshot 2023-01-06 at 18 31 34" src="https://user-images.githubusercontent.com/6829422/211121998-4f5aba1f-8ea3-469e-9276-3aef02e6db46.png">


