### PR TITLE
Only fetch WAQ issues assigned to the current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.2
+- Updated the graphQL query to only fetch WAQ issues assigned to the current user
+
 #1.2.1
 - Fixed unique key prop warning in ListItemIssue component
 - Removed unused token and file to make k2 public

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -158,6 +158,7 @@ function getWAQIssues() {
     query += ' label:Bug';
     query += ' NOT hold in:title';
     query += ' -label:Reviewing';
+    query += ` assignee:${getCurrentUser()}`;
 
     const graphQLQuery = `
         query($cursor:String) {


### PR DESCRIPTION
## Fixed issue
https://github.com/Expensify/Expensify/issues/254177

## Tests
1. Followed [these instructions](https://github.com/Expensify/k2-extension#from-the-source-code-for-development) on dev and loaded the unpacked extension
2. Verified the `WAQ` section on the K2 dashboard only displayed issues assigned to me