### PR TITLE
Remove demolition related code from K2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #1.2.3
-- Remove demolition shortcut
+- Removed demolition shortcut
 
 #1.2.2
 - Updated to show WAQ issues assigned to the current user by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.3
+- Remove demolition shortcut
+
 #1.2.2
 - Updated to show WAQ issues assigned to the current user by default
 - Added a checkbox in the WAQ panel to toggle between displaying all WAQ issues and those assigned to the current user

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -47,7 +47,6 @@ $color-dark-yellow: #DAA520;
 .k2-improvement,
 .k2-task,
 .k2-external,
-.k2-demolition,
 .k2-newfeature {
   background-image: none !important;
 }
@@ -66,7 +65,6 @@ $color-dark-yellow: #DAA520;
 .k2-task.active { background-color: #9C5959 !important; color: white; }
 .k2-newfeature.active { background-color: #A52A2A !important; color: white; }
 .k2-external.active { background-color: #A7B8EF !important; color: white; }
-.k2-demolition.active { background-color: #6EB7C1 !important; color: white; }
 
 .k2-reviewing {
   &.active { background-color: $color-neutral; }

--- a/src/js/module/K2pickerarea/K2PickerareaPicker.js
+++ b/src/js/module/K2pickerarea/K2PickerareaPicker.js
@@ -34,10 +34,6 @@ class K2PickerareaPicker extends React.Component {
                 className: `${defaultBtnClass} inactive k2-external`,
                 shortName: '👥 External',
             },
-            Demolition: {
-                className: `${defaultBtnClass} inactive k2-demolition`,
-                shortName: '💣 Demolition',
-            },
         };
         // eslint-disable-next-line rulesdir/prefer-underscore-method
         $('.js-issue-labels .IssueLabel').each((i, el) => {


### PR DESCRIPTION
When we merged teams, we decided to get rid of the Demolition team and now that WAQ is over, I finally had some time to deal with the leftover code.

Part of https://github.com/Expensify/Expensify/issues/256949