### PR TITLE
Update link to open K2 for contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#1.2.4
+- Updated the instructions to open the K2 dashboard in the App repo
+- Added link to the PAT instructions in the FormPassword form
+
 #1.2.3
 - Removed demolition shortcut
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ KS Browser Extension
 GitHub UI integration for KS - Kernel Scheduling Method
 
 # Installing the Chrome Extension
-## Easy (auto-updating)
+## Easy (auto-updating), only for internal employees
 1. Download the extension from [here](https://chrome.google.com/webstore/detail/k2-for-github/hmhoemhekchomabhoccbidjnoenbphno?hl=en-US)
 1. Click on 'Add to Chrome'
 
-## From the Source Code for development
+## From the Source Code (for development or for external contributors)
 1. Go to `chrome://extensions`
 1. Make sure you have _Developer Mode_ enabled at the top
 1. Click _Load Unpacked Extension_
 1. Navigate to the `dist` folder and select it
-    - Note: Do this after running `npm i` then `npm run web`
+    - Note: Do this after running `npm i` then `npm run web` or `npm run build`
 
 # Installing on Firefox
 ## The "published" version
 1. https://stackoverflow.com/c/expensify/questions/7053/7054#7054
 
-## From the Source Code for development
+## From the Source Code (for development or for external contributors)
 1. Open up this page in firefox: `about:debugging#/runtime/this-firefox`
 1. Click **Load temporary add-on**
 1. Select the `dist/manifest.json` file in this repo (really any file within the dist should work) [more info](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#Trying_it_out)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub UI integration for KS - Kernel Scheduling Method
 1. Open up this page in firefox: `about:debugging#/runtime/this-firefox`
 1. Click **Load temporary add-on**
 1. Select the `dist/manifest.json` file in this repo (really any file within the dist should work) [more info](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#Trying_it_out)
-1. go to https://github.com/Expensify/App#k2
+1. Go to https://github.com/Expensify/App#k2
     Note: If this doesn't load you may need to run `npm run build` within the root of the repo to ensure all files have been generated properly (we don't save all of the dist directory to the repo).
 
 ## NOTE: It Requires a Personal Access token

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub UI integration for KS - Kernel Scheduling Method
 1. Open up this page in firefox: `about:debugging#/runtime/this-firefox`
 1. Click **Load temporary add-on**
 1. Select the `dist/manifest.json` file in this repo (really any file within the dist should work) [more info](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#Trying_it_out)
-1. go to https://github.com/Expensify/Expensify#k2
+1. go to https://github.com/Expensify/App#k2
     Note: If this doesn't load you may need to run `npm run build` within the root of the repo to ensure all files have been generated properly (we don't save all of the dist directory to the repo).
 
 ## NOTE: It Requires a Personal Access token
@@ -56,7 +56,7 @@ In order to test your changes, you need to have the extension loaded into Chrome
 1. Click on **Load Unpacked Extension**
 1. Select the `dist` folder in this repo
 1. Now the extension should be installed and enabled
-1. Go to https://github.com/Expensify/Expensify#k2 and you should see the extension working
+1. Go to https://github.com/Expensify/App#k2 and you should see the extension working
 
 ### Caution When Using the Publicly Installed Extension
 Sometimes it is necessary to install and enable the public version of the extension. You want to take care not to have both the public extension and the local extension enabled at the same time. It will make everything run twice and you'll get a lot of DOM conflicts, plus API calls will run twice so you'll hit rate limits faster.

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/module/dashboard/FormPassword.js
+++ b/src/js/module/dashboard/FormPassword.js
@@ -63,7 +63,13 @@ class FormPassword extends React.Component {
                                     />
 
                                     <p>
-                                        A personal access token is required to make custom queries against the GitHub.com API.
+                                        A
+                                        {' '}
+                                        <a href="https://github.com/Expensify/k2-extension/#note-it-requires-a-personal-access-token" target="_blank" rel="noopener noreferrer">
+                                            Personal Access Token
+                                        </a>
+                                        {' '}
+                                        is required to make custom queries against the GitHub.com API.
                                     </p>
                                 </div>
 


### PR DESCRIPTION
cc @tgolen 

This PR updates the instructions to open the K2 dashboard in the App repo, since the E/E repo is only for internal employees, and external contributors can't access it.

$ https://github.com/Expensify/Expensify/issues/260956

Tests:

1. Open https://github.com/Expensify/App#k2 and verify the K2 is loading

<img width="1506" alt="Screenshot 2023-02-07 at 16 51 13" src="https://user-images.githubusercontent.com/6829422/217387204-3068a258-c17e-408d-81d3-c56422769b91.png">

2. Update this [line](https://github.com/Expensify/k2-extension/blob/bfac2b97b70965297ca92107c87823860a54067c/src/js/module/dashboard/index.js#L52) to show the password form and verify the link opens the PAT instructions in a new tab:

<img width="1416" alt="Screenshot 2023-02-07 at 16 49 43" src="https://user-images.githubusercontent.com/6829422/217387441-9c80093f-dfb1-4caf-a930-d87c5eb684a5.png">


 

