### PR TITLE
Fix Label assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.5
+- Fixing error when trying to update Labels. GitHub now uses spaces on the components we used to get the repository name
+
 #1.2.4
 - Updated the instructions to open the K2 dashboard in the App repo
 - Added link to the PAT instructions in the FormPassword form

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.5",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4347,8 +4347,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+ssh://git@github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
-      "from": "expensify-common@git+https://github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
+      "version": "git+https://github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
+      "from": "git+https://github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",
@@ -4359,7 +4359,7 @@
         "react": "16.12.0",
         "react-dom": "16.12.0",
         "semver": "^7.3.5",
-        "simply-deferred": "simply-deferred@git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+        "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
         "underscore": "1.13.1"
       },
       "dependencies": {
@@ -7520,8 +7520,8 @@
       "integrity": "sha512-5oiAsoW88SOYDg/0cleJ2vJDqv98FJUbFQYEnH4sdMtEn3AAT3lb7BkTGW8HO/t3Vk9VOruwxUUnO4tzuxzCsw=="
     },
     "react-native-onyx": {
-      "version": "git+ssh://git@github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
-      "from": "react-native-onyx@git+https://github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
+      "version": "git+https://github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
+      "from": "git+https://github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
       "requires": {
         "ascii-table": "0.0.9",
         "lodash": "^4.17.21",
@@ -8178,8 +8178,8 @@
       "dev": true
     },
     "simply-deferred": {
-      "version": "git+ssh://git@github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-      "from": "simply-deferred@git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5"
+      "version": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+      "from": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5"
     },
     "slash": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4347,8 +4347,8 @@
       }
     },
     "expensify-common": {
-      "version": "git+https://github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
-      "from": "git+https://github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
+      "version": "git+ssh://git@github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
+      "from": "expensify-common@git+https://github.com/Expensify/expensify-common.git#5fb22bd4a3619eb9fe9e2a9c0dc25e291863a2a2",
       "requires": {
         "classnames": "2.3.1",
         "clipboard": "2.0.4",
@@ -4359,7 +4359,7 @@
         "react": "16.12.0",
         "react-dom": "16.12.0",
         "semver": "^7.3.5",
-        "simply-deferred": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+        "simply-deferred": "simply-deferred@git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
         "underscore": "1.13.1"
       },
       "dependencies": {
@@ -7520,8 +7520,8 @@
       "integrity": "sha512-5oiAsoW88SOYDg/0cleJ2vJDqv98FJUbFQYEnH4sdMtEn3AAT3lb7BkTGW8HO/t3Vk9VOruwxUUnO4tzuxzCsw=="
     },
     "react-native-onyx": {
-      "version": "git+https://github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
-      "from": "git+https://github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
+      "version": "git+ssh://git@github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
+      "from": "react-native-onyx@git+https://github.com/Expensify/react-native-onyx.git#83fae2c656c4f35515577a92558f11f531654ace",
       "requires": {
         "ascii-table": "0.0.9",
         "lodash": "^4.17.21",
@@ -8178,8 +8178,8 @@
       "dev": true
     },
     "simply-deferred": {
-      "version": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
-      "from": "git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5"
+      "version": "git+ssh://git@github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5",
+      "from": "simply-deferred@git+https://github.com/Expensify/simply-deferred.git#77a08a95754660c7bd6e0b6979fdf84e8e831bf5"
     },
     "slash": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -32,7 +32,7 @@ function getCurrentUser() {
  * @returns {String}
  */
 function getRepo() {
-    return $('#repository-container-header strong a').text();
+    return $('#repository-container-header strong a').text().trim();
 }
 
 /**
@@ -41,7 +41,7 @@ function getRepo() {
  * @returns {String}
  */
 function getOwner() {
-    return $('#repository-container-header .author a').text();
+    return $('#repository-container-header .author a').text().trim();
 }
 
 /**


### PR DESCRIPTION
Labels are broken as per $https://github.com/Expensify/Expensify/issues/262805

GH now added spaces on before and after the property we use to determine the repo (`#repository-container-header strong a`). I've added a trim to remove that.

### How to test:

1. Run project locally following [readme.md](https://github.com/Expensify/k2-extension)
2. Try to assign a label in a test issue clicking on our k2 extension buttons (you can use this one https://github.com/Expensify/Expensify/issues/262808)

### Test evidence:

https://user-images.githubusercontent.com/5818999/219220283-e8af1a7c-33b7-46b4-86ba-736998348281.mov

