### PR TITLE
Bump version to account for vulnerability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #1.2.7
-- Fixed duplicate count items in WAQ section.
+- Fixed duplicate item count in WAQ section.
 - Bumped package versions to fix security vulnerabilities.
 
 #1.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 #1.2.7
+- Fixed duplicate count items in WAQ section.
+- Bumped package versions to fix security vulnerabilities.
+
+#1.2.7
 - Added a count of items for each header.
 
 #1.2.6

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {


### PR DESCRIPTION
I fixed a few security vulnerabilities below so we need to bump the version to publish them.

https://github.com/Expensify/k2-extension/pull/148
https://github.com/Expensify/k2-extension/pull/147
https://github.com/Expensify/k2-extension/pull/146
https://github.com/Expensify/k2-extension/pull/143