### PR TITLE
Add Product Manager Review Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.10
+- Added button to the issue sidebar for adding the product manager application review comment
+
 #1.2.9
 - Updated logic for WAQ groupings
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/module/K2comments/CommentsButtons.js
+++ b/src/js/module/K2comments/CommentsButtons.js
@@ -59,6 +59,18 @@ class CommentsButtons extends React.Component {
                     </button>
                 </BtnGroup>
 
+                <BtnGroup>
+                    <button
+                        type="button"
+                        className="btn btn-sm"
+                        onClick={() => this.addParticipationComment('I have read and reviewed this Product Manager Application!')}
+                    >
+                        <span role="img" aria-label="reviewed product manager emojis">
+                            📝 Reviewed Product Manager Application
+                        </span>
+                    </button>
+                </BtnGroup>
+
                 {this.state.shouldShowConfirmationMessage && (
                     <div>Comment added! Please wait a moment for it to appear</div>
                 )}


### PR DESCRIPTION
Context: 

We currently require 2/3 participation to pass or fail product manager track applications. This often creates a tragedy of the commons, where the application lead is consistently soliciting for reviews. In turn, applications are taking much longer to pass/fail than they should. This button mimics the project manager review button that already exists. 

Fixes $ https://github.com/Expensify/Expensify/issues/276436

The complementary PR that creates the chore and the 20 assignments is here: https://github.com/Expensify/Web-Expensify/pull/37089

I've never created a K2 extension button before, so am unsure on testing steps

cc @grgia as you did the last one of these would you be down to review? 