### PR TITLE
Update getCurrentUser() to fetch the current user's Github username from the meta tag instead of the avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.11
+- Updated getCurrentUser() to retrieve the user's Github username from the meta tag instead of the header avatar
+
 #1.2.10
 - Added button to the issue sidebar for adding the product manager application review comment
 - Added a confirmation button for sending participation comments

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -22,7 +22,7 @@ function getOctokit() {
  */
 function getCurrentUser() {
     const params = new URLSearchParams(window.location.search);
-    const currentUser = params.get('currentUser') ? params.get('currentUser') : $('.Header-link .avatar').attr('alt');
+    const currentUser = params.get('currentUser') ? params.get('currentUser') : $("meta[name=user-login]").attr('content');
     return currentUser.replace('@', '');
 }
 

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -22,7 +22,7 @@ function getOctokit() {
  */
 function getCurrentUser() {
     const params = new URLSearchParams(window.location.search);
-    const currentUser = params.get('currentUser') ? params.get('currentUser') : $("meta[name=user-login]").attr('content');
+    const currentUser = params.get('currentUser') ? params.get('currentUser') : $('meta[name=user-login]').attr('content');
     return currentUser.replace('@', '');
 }
 


### PR DESCRIPTION
Slack: https://expensify.slack.com/archives/C06N6E4RF/p1686913493813059

[getCurrentUser()](https://github.com/Expensify/k2-extension/blob/d43f5b1fc6e72f46f812017f0f06c7483074f300/src/js/lib/api.js#L23) was using the classes `.Header-link .avatar` and then fetching the value of the `alt` attribute in order to fetch the current user's Github username. But it looks like the parent CSS class was updated to `.AppHeader` and that led to k2 not being able to load the dashboard at all:

<img width="1080" alt="Screenshot 2023-06-16 at 3 22 43 PM" src="https://github.com/Expensify/k2-extension/assets/12268372/fae4dd47-e4c3-48c1-a49e-91981335a8ec">

<img width="663" alt="Screenshot 2023-06-16 at 3 25 15 PM" src="https://github.com/Expensify/k2-extension/assets/12268372/d3c95912-4f99-4e6f-9e9b-5f7fdee9d688">

This is assuming the meta tag isn't really something that would change vs the class for the avatar which might change at some point 