### PR TITLE
Remove unused permissions for storage and cookies Chrome APIs

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -20,8 +20,6 @@
 
   "permissions": [
     "*://api.github.com/*",
-    "storage",
-    "cookies",
     "webNavigation",
     "tabs"
   ],


### PR DESCRIPTION
We're not using Chrome's Storage API and chrome.cookies, so let's remove them.

More context on Slack: https://expensify.slack.com/archives/C03TQ48KC/p1686931078184029?thread_ts=1686854265.325289&cid=C03TQ48KC