### PR TITLE
Fetch repository name, owner and issue number from the current URL instead of relying on the DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.12
+- Fetch repository name, owner and issue number from URL instead of relying on the DOM
+
 #1.2.11
 - Updated getCurrentUser() to retrieve the user's Github username from the meta tag instead of the header avatar
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -27,34 +27,7 @@ function getCurrentUser() {
 }
 
 /**
- * Returns the name of the current repo
- *
- * @returns {String}
- */
-function getRepo() {
-    return $('#repository-container-header strong a').text().trim();
-}
-
-/**
- * Returns the name of the current repo owner
- *
- * @returns {String}
- */
-function getOwner() {
-    return $('#repository-container-header .author a').text().trim();
-}
-
-/**
- * Returns the issue number that is read off the DOM
- *
- * @returns {String}
- */
-function getIssueNumber() {
-    return $('.gh-header-number').first().text().replace('#', '');
-}
-
-/**
- * Returns the repo name, repo owner and issue number for calls to the Github API
+ * Returns the name of the repository, the repo owner and the issue number from the current url for calls to the Github API
  *
  * @returns {Object}
  */

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -366,7 +366,7 @@ function getEngineeringIssues() {
  * @returns {Promise}
  */
 function addLabel(label) {
-    return getOctokit().rest.issues.addLabels(_.assign(getRequestParams(), {labels: [label]}));
+    return getOctokit().rest.issues.addLabels({...getRequestParams(), labels: [label]});
 }
 
 /**
@@ -375,7 +375,7 @@ function addLabel(label) {
  * @returns {Promise}
  */
 function removeLabel(label) {
-    return getOctokit().rest.issues.removeLabel(_.assign(getRequestParams(), {name: label}));
+    return getOctokit().rest.issues.removeLabel({...getRequestParams(), name: label});
 }
 
 /**
@@ -390,7 +390,7 @@ function getDailyImprovements() {
  * @returns {Promise}
  */
 function addComment(comment) {
-    return getOctokit().rest.issues.createComment(_.assign(getRequestParams(), {body: comment}));
+    return getOctokit().rest.issues.createComment({...getRequestParams(), body: comment});
 }
 
 export {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -54,6 +54,23 @@ function getIssueNumber() {
 }
 
 /**
+ * Returns the repo name, repo owner and issue number for calls to the Github API
+ *
+ * @returns {Object}
+ */
+function getRequestParams() {
+    const url = window.location.href;
+    const regex = /github.com\/(\w*)\/(\w*)\/issues\/(\d*)/;
+    const matches = url.match(regex);
+
+    return {
+        owner: matches[1],
+        repo: matches[2],
+        issue_number: matches[3],
+    };
+}
+
+/**
  * Return all of our milestone data
  *
  * @returns {Promise}
@@ -376,12 +393,9 @@ function getEngineeringIssues() {
  * @returns {Promise}
  */
 function addLabel(label) {
-    return getOctokit().rest.issues.addLabels({
-        repo: getRepo(),
-        owner: getOwner(),
-        issue_number: getIssueNumber(),
-        labels: [label],
-    });
+    const params = getRequestParams();
+    params.labels = [label];
+    return getOctokit().rest.issues.addLabels(params);
 }
 
 /**

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -287,7 +287,7 @@ query {
 
 function getCheckRuns(repo, headSHA) {
     return getOctokit().rest.checks.listForRef({
-        owner: getOwner(),
+        owner: getRequestParams().owner,
         repo,
         ref: headSHA,
     });
@@ -393,9 +393,7 @@ function getEngineeringIssues() {
  * @returns {Promise}
  */
 function addLabel(label) {
-    const params = getRequestParams();
-    params.labels = [label];
-    return getOctokit().rest.issues.addLabels(params);
+    return getOctokit().rest.issues.addLabels(_.assign(getRequestParams(), {labels: [label]}));
 }
 
 /**
@@ -404,12 +402,7 @@ function addLabel(label) {
  * @returns {Promise}
  */
 function removeLabel(label) {
-    return getOctokit().rest.issues.removeLabel({
-        repo: getRepo(),
-        owner: getOwner(),
-        issue_number: getIssueNumber(),
-        name: label,
-    });
+    return getOctokit().rest.issues.removeLabel(_.assign(getRequestParams(), {name: label}));
 }
 
 /**
@@ -424,12 +417,7 @@ function getDailyImprovements() {
  * @returns {Promise}
  */
 function addComment(comment) {
-    return getOctokit().rest.issues.createComment({
-        repo: getRepo(),
-        owner: getOwner(),
-        issue_number: getIssueNumber(),
-        body: comment,
-    });
+    return getOctokit().rest.issues.createComment(_.assign(getRequestParams(), {body: comment}));
 }
 
 export {


### PR DESCRIPTION
From slack: https://expensify.slack.com/archives/C06N6E4RF/p1687196296716529

The Github UI update led to broken label selectors since we're relying on CSS classes in the DOM but these are likely to change. Let's fetch the details we need to make API requests to Github from the url instead of the DOM.

Test issue here: https://github.com/Expensify/Expensify/issues/293348