### PR TITLE
Fix for button to add PR checklist to pull requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.13
+- Improve the regex that fetches the repository name, owner and issue number from the current URL work for pull requests as well
+
 #1.2.12
 - Fetch repository name, owner and issue number from URL instead of relying on the DOM
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -28,12 +28,14 @@ function getCurrentUser() {
 
 /**
  * Returns the name of the repository, the repo owner and the issue number from the current url for calls to the Github API
+ * Issue URLs are in the format: github.com/<repoName>/<owner>/issues/<issue-number> Example: https://github.com/Expensify/App/issues/16640
+ * PR URLs are in the format: github.com/<repoName>/<owner>/pulls/<issue-number> Example: https://github.com/Expensify/App/pull/21242
  *
  * @returns {Object}
  */
 function getRequestParams() {
     const url = window.location.href;
-    const regex = /github.com\/(\w*)\/(\w*)\/issues\/(\d*)/;
+    const regex = /github.com\/(\w*)\/(\w*)\/(?:issues|pull)\/(\d*)/;
     const matches = url.match(regex);
 
     return {


### PR DESCRIPTION
Improved the regex (that fetches repo name, owner and issue number) to also work for pull request URLs.

<img width="1444" alt="Screenshot 2023-06-21 at 8 39 56 PM" src="https://github.com/Expensify/k2-extension/assets/12268372/5fb4e3b0-0318-4abf-9fe6-775cd45c530c">

Test PR: https://github.com/Expensify/App/pull/21242