### PR TITLE
Provide a way to manage GH issue owner

### DIFF
--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -540,3 +540,8 @@ $color-dark-yellow: #DAA520;
   position: sticky;
   top: 60px;
 }
+
+.js-issue-assignees .k2button {
+  position: absolute;
+  left: 106%;
+}

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -541,7 +541,7 @@ $color-dark-yellow: #DAA520;
   top: 60px;
 }
 
-.js-issue-assignees .k2button {
+.js-issue-assignees .k2-button {
   position: absolute;
   left: 106%;
 }

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -21,7 +21,7 @@ $color-darker-green: #2cb528;
 $color-dark-yellow: #DAA520;
 
 .owner {
-  color: $color-dark-yellow;
+  color: $color-dark-yellow !important;
 }
 
 .k2dashboard,

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -20,6 +20,10 @@ $color-light-blue: #12a4d5;
 $color-darker-green: #2cb528;
 $color-dark-yellow: #DAA520;
 
+.owner {
+  color: $color-dark-yellow;
+}
+
 .k2dashboard,
 .passwordform {
     max-width: 1680px;

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -545,3 +545,9 @@ $color-dark-yellow: #DAA520;
   position: absolute;
   left: 106%;
 }
+
+.alert {
+  color: $color-alert;
+  font-weight: bold;
+  margin: 8px 16px;
+}

--- a/src/js/component/list-item/ListItemIssue.js
+++ b/src/js/component/list-item/ListItemIssue.js
@@ -51,12 +51,18 @@ class ListItemIssue extends React.Component {
         this.isHelpWanted = _.some(this.props.issue.labels, {name: 'Help Wanted'}) ? ' help-wanted' : '';
         this.isContributorAssigned = this.isExternal && !this.isHelpWanted ? ' contributor-assigned' : '';
         this.isUnderReview = _.find(this.props.issue.labels, label => label.name.toLowerCase() === 'reviewing');
+        this.isCurrentUserOwner = this.props.issue.currentUserIsOwner;
     }
 
     render() {
         this.parseIssue();
         return (
             <div className="panel-item">
+                {this.isCurrentUserOwner && (
+                    <span className="owner">
+                        {'★ '}
+                    </span>
+                )}
                 <a
                     href={this.props.issue.url}
                     className={this.getClassName()}

--- a/src/js/component/panel/PanelIssues.js
+++ b/src/js/component/panel/PanelIssues.js
@@ -64,6 +64,9 @@ const PanelIssues = (props) => {
         return null;
     }
 
+    // Put the issues owned by the current user at the top of the list
+    const sortedData = _.sortBy(filteredData, 'currentUserIsOwner');
+
     return (
         <div className={`panel ${props.extraClass}`}>
             <Title
@@ -77,7 +80,7 @@ const PanelIssues = (props) => {
                 </div>
             ) : (
                 <div>
-                    {_.map(filteredData, issue => <ListItemIssue key={`issue_raw_${issue.id}`} issue={issue} />)}
+                    {_.map(sortedData, issue => <ListItemIssue key={`issue_raw_${issue.id}`} issue={issue} />)}
                 </div>
             )}
         </div>

--- a/src/js/lib/actions/Issues.js
+++ b/src/js/lib/actions/Issues.js
@@ -25,9 +25,29 @@ function getDailyImprovements() {
 function getAllAssigned() {
     API.getIssuesAssigned()
         .then((issues) => {
+            const currentUser = API.getCurrentUser();
+            const issuesMarkedWithOwner = _.reduce(issues, (finalObject, issue) => {
+                const regexResult = issue.body.match(/Current Issue Owner:\s@(?<owner>\S+)/i);
+                const currentOwner = regexResult && regexResult.groups && regexResult.groups.owner;
+                if (!currentOwner || currentOwner !== currentUser) {
+                    return {
+                        ...finalObject,
+                        [issue.id]: issue,
+                    };
+                }
+
+                return {
+                    ...finalObject,
+                    [issue.id]: {
+                        ...issue,
+                        currentUserIsOwner: true,
+                    },
+                };
+            }, {});
+
             // Always use set() here because there is no way to remove issues from Onyx
             // that get closed and are no longer assigned
-            ReactNativeOnyx.set(ONYXKEYS.ISSUES.ASSIGNED, issues);
+            ReactNativeOnyx.set(ONYXKEYS.ISSUES.ASSIGNED, issuesMarkedWithOwner);
         });
 }
 

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -325,6 +325,7 @@ function getIssues(assignee = 'none', labels) {
                         url
                         createdAt
                         updatedAt
+                        body
                         assignees(first: 100) {
                           nodes {
                             avatarUrl

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -10,7 +10,12 @@ let octokit;
  */
 function getOctokit() {
     if (!octokit) {
-        octokit = new Octokit({auth: Preferences.getGitHubToken()});
+        /* eslint-disable-next-line no-console */
+        console.log('authenticate with auth token', Preferences.getGitHubToken());
+        octokit = new Octokit({
+            auth: Preferences.getGitHubToken(),
+            userAgent: 'expensify-k2-extension',
+        });
     }
     return octokit;
 }
@@ -395,6 +400,21 @@ function addComment(comment) {
     return getOctokit().rest.issues.createComment({...getRequestParams(), body: comment});
 }
 
+/**
+ * @returns {Promise}
+ */
+function getCurrentIssueDescription() {
+    return getOctokit().rest.issues.get({...getRequestParams()});
+}
+
+/**
+ * @param {String} body
+ * @returns {Promise}
+ */
+function setCurrentIssueBody(body) {
+    return getOctokit().rest.issues.update({...getRequestParams(), body});
+}
+
 export {
     addComment,
     getCheckRuns,
@@ -407,4 +427,6 @@ export {
     getMilestones,
     getCurrentUser,
     getPullsByType,
+    getCurrentIssueDescription,
+    setCurrentIssueBody,
 };

--- a/src/js/lib/pages/github/issue.js
+++ b/src/js/lib/pages/github/issue.js
@@ -9,6 +9,36 @@ import ToggleReview from '../../../module/ToggleReview/ToggleReview';
 import K2comments from '../../../module/K2comments/K2comments';
 import ONYXKEYS from '../../../ONYXKEYS';
 
+/**
+ * This method is all about adding the "issue owner" functionality which melvin will use to see who should be providing ksv2 updates to an issue.
+ */
+const refreshAssignees = () => {
+    // Do nothing if there is only one person assigned
+    if ($('.js-issue-assignees > p > span').length <= 1) {
+        return;
+    }
+
+    /* eslint-disable rulesdir/prefer-underscore-method */
+    $('.js-issue-assignees > p > span').each((i, el) => {
+        // If the button was already drawn, exit early
+        if ($(el).find('.k2button').length) {
+            return;
+        }
+
+        // Check if there is an owner already
+        const ghDescription = $('.comment-body').text();
+        const issueOwner = ghDescription.match(/Current Issue Owner:\s(@\S+)/gi);
+
+        console.log(issueOwner)
+
+        $(el).append(`
+            <button type="button" class="Button Button--secondary Button--small flex-md-order-2 m-0 k2button">
+                Make owner
+            </button>
+        `);
+    });
+};
+
 const refreshPicker = function () {
     // Add our wrappers to the DOM which all the React components will be rendered into
     if (!$('.k2picker-wrapper').length) {
@@ -38,6 +68,7 @@ export default function () {
 
     IssuePage.setup = function () {
         setTimeout(refreshPicker, 500);
+        setTimeout(refreshAssignees, 500);
 
         // Listen for when the sidebar is redrawn, then redraw our pickers
         $(document).bind('DOMNodeRemoved', (e) => {
@@ -45,6 +76,7 @@ export default function () {
                 return;
             }
             setTimeout(refreshPicker, 500);
+            setTimeout(refreshAssignees, 500);
         });
     };
 

--- a/src/js/lib/pages/github/issue.js
+++ b/src/js/lib/pages/github/issue.js
@@ -14,7 +14,6 @@ import ONYXKEYS from '../../../ONYXKEYS';
  * This method is all about adding the "issue owner" functionality which melvin will use to see who should be providing ksv2 updates to an issue.
  */
 const refreshAssignees = () => {
-    console.log('refreshAssignees');
     // Always start by erasing whatever was drawn before (so it always starts from a clean slate)
     $('.js-issue-assignees .k2-element').remove();
 
@@ -30,20 +29,33 @@ const refreshAssignees = () => {
 
     $('.js-issue-assignees > p > span').each((i, el) => {
         const assignee = $(el).find('.assignee span').text();
-        console.log(assignee, currentOwner);
         if (assignee === currentOwner) {
             $(el).append(`
-                <button type="button" class="Button Button--secondary Button--small flex-md-order-2 m-0 k2-element k2-button">
-                    Remove owner
+                <button type="button" class="Button flex-md-order-2 m-0 k2-element k2-button k2-button-remove-owner" data-owner="${currentOwner}">
+                    ★
                 </button>
             `);
         } else {
             $(el).append(`
-                <button type="button" class="Button Button--secondary Button--small flex-md-order-2 m-0 k2-element k2-button">
-                    Make owner
+                <button type="button" class="Button flex-md-order-2 m-0 k2-element k2-button k2-button-make-owner" data-owner="${assignee}">
+                    ☆
                 </button>
             `);
         }
+    });
+
+    $('.k2-button-remove-owner').off('click').on('click', (e) => {
+        e.preventDefault();
+        const owner = $(e.target).data('owner');
+        console.log('remove owner', owner);
+        return false;
+    });
+
+    $('.k2-button-make-owner').off('click').on('click', (e) => {
+        e.preventDefault();
+        const owner = $(e.target).data('owner');
+        console.log('make owner', owner);
+        return false;
     });
 };
 

--- a/src/js/lib/pages/github/issue.js
+++ b/src/js/lib/pages/github/issue.js
@@ -74,9 +74,10 @@ const refreshAssignees = () => {
     // Always start by erasing whatever was drawn before (so it always starts from a clean slate)
     $('.js-issue-assignees .k2-element').remove();
 
-    // Do nothing if there is only one person assigned
+    // Do nothing if there is only one person assigned. Owners can only be set when there are
+    // multiple assignees
     if ($('.js-issue-assignees > p > span').length <= 1) {
-        // return;
+        return;
     }
 
     // Check if there is an owner for the issue
@@ -89,7 +90,7 @@ const refreshAssignees = () => {
         const assignee = $(el).find('.assignee span').text();
         if (assignee === currentOwner) {
             $(el).append(`
-                <button type="button" class="Button flex-md-order-2 m-0 k2-element k2-button k2-button-remove-owner" data-owner="${currentOwner}">
+                <button type="button" class="Button flex-md-order-2 m-0 owner k2-element k2-button k2-button-remove-owner" data-owner="${currentOwner}">
                     ★
                 </button>
             `);

--- a/src/js/lib/pages/github/issue.js
+++ b/src/js/lib/pages/github/issue.js
@@ -96,7 +96,7 @@ const refreshAssignees = () => {
         } else {
             $(el).append(`
                 <button type="button" class="Button flex-md-order-2 m-0 k2-element k2-button k2-button-make-owner" data-owner="${assignee}">
-                    ☼
+                    ○
                 </button>
             `);
         }

--- a/src/js/module/dashboard/Legend.js
+++ b/src/js/module/dashboard/Legend.js
@@ -41,6 +41,11 @@ const Legend = () => {
                 {' '}
                 External
             </div>
+            <div>
+                <span className="owner">★</span>
+                {' '}
+                Issue owner
+            </div>
             <div className="issue">
                 <sup>I</sup>
                 {' '}


### PR DESCRIPTION
This PR adds a small UI to the assignees section of a GH issue to manage the owner of an issue. It will only appear when there are multiple assignees.

<img width="461" alt="image" src="https://github.com/Expensify/k2-extension/assets/1228807/0223033e-ec0c-43c6-bbc7-59227faa3224">

It also surfaces the owner information in the K2 dashboard so you can easily see the issues you are the owner of. It puts them at the top of the list and puts the yellow star next to them.

<img width="620" alt="image" src="https://github.com/Expensify/k2-extension/assets/1228807/aa33a77d-038d-4582-b5e2-d6552fb6bc21">
