### PR TITLE
Fix the regex for issue owner to be more accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.2.15
+- Added issue owner functionality
+
 #1.2.14
 - Bumped package versions to fix security vulnerabilities.
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/actions/Issues.js
+++ b/src/js/lib/actions/Issues.js
@@ -27,7 +27,7 @@ function getAllAssigned() {
         .then((issues) => {
             const currentUser = API.getCurrentUser();
             const issuesMarkedWithOwner = _.reduce(issues, (finalObject, issue) => {
-                const regexResult = issue.body.match(/Current Issue Owner:\s@(?<owner>\S+)/i);
+                const regexResult = issue.body.match(/Current Issue Owner:\s@(?<owner>[a-z0-9-]+)/i);
                 const currentOwner = regexResult && regexResult.groups && regexResult.groups.owner;
                 if (!currentOwner || currentOwner !== currentUser) {
                     return {


### PR DESCRIPTION
The regex was matching `tgolen</details>` which was keeping the k2 dashboard from showing the issues you are an owner of. With this change, it now properly matches only `tgolen` and will properly show the issues you own:

<img width="532" alt="image" src="https://github.com/Expensify/k2-extension/assets/1228807/d5470585-35ba-4767-a06c-1087976076a3">
