### PR TITLE
Keep issue filter text black in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.3.1
+- Made new filter work in dark mode
+
 #1.3.0
 - Add filters for held and under review issues in the assigned issues sections
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -556,3 +556,7 @@ $color-dark-yellow: #DAA520;
   font-weight: bold;
   margin: 8px 16px;
 }
+
+.issue-filter {
+  color: $color-black;
+}

--- a/src/js/module/dashboard/ListIssuesAssigned.js
+++ b/src/js/module/dashboard/ListIssuesAssigned.js
@@ -75,7 +75,7 @@ class ListIssuesAssigned extends React.Component {
 
         return (
             <div className="mb-3">
-                <div className="panel-title">
+                <div className="panel-title issue-filter">
                     <form className="form-inline">
                         <strong>Hide:</strong>
                         <div className="checkbox">


### PR DESCRIPTION
$ https://github.com/Expensify/Expensify/issues/331612#issuecomment-1790759072

<img width="422" alt="image" src="https://github.com/Expensify/k2-extension/assets/5487802/b1cdfd26-066e-4703-bfc9-77b014a5e57c">
