### PR TITLE
Update the regex to prevent errors on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.3.4
+- Fix console error for regex on dashboard page
+
 #1.3.3
 - Change the color of non-issue owners to be grey
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -40,7 +40,7 @@ function getCurrentUser() {
  */
 function getRequestParams() {
     const url = window.location.href;
-    const regex = /github.com\/(\w*)\/(\w*)\/(?:issues|pull)\/(\d*)/;
+    const regex = /github.com\/(\w*)\/(\w*)(?:\/(?:issues|pull)\/(\d*))?/;
     const matches = url.match(regex);
 
     return {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -40,13 +40,13 @@ function getCurrentUser() {
  */
 function getRequestParams() {
     const url = window.location.href;
-    const regex = /github.com\/(\w*)\/(\w*)(?:\/(?:issues|pull)\/(\d*))?/;
+    const regex = /github.com\/(?<owner>\w*)\/(?<repo>\w*)(?:\/(?:issues|pull)\/(?<issue_number>\d*))?/;
     const matches = url.match(regex);
 
     return {
-        owner: matches[1],
-        repo: matches[2],
-        issue_number: matches[3],
+        owner: (matches && matches.groups && matches.groups.owner) || '',
+        repo: (matches && matches.groups && matches.groups.repo) || '',
+        issue_number: (matches && matches.groups && matches.groups.issue_number) || '',
     };
 }
 


### PR DESCRIPTION
I noticed this error today, I have no idea why it all of a sudden started to show up. I updated the regex to make the issue/pull stuff optional, switched to using named capture groups, and protected against null matches.

![image](https://github.com/Expensify/k2-extension/assets/1228807/e9ff4792-e46b-445c-bdae-34d90e9169c1)

I tested it to ensure all three URL types are passing the regex now:
![image](https://github.com/Expensify/k2-extension/assets/1228807/7f9a997b-0580-422b-95d8-f2ff23c8a8ae)


https://regex101.com/r/369Aua/3