### PR TITLE
Remove tabs permission

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -20,8 +20,7 @@
 
   "permissions": [
     "*://api.github.com/*",
-    "webNavigation",
-    "tabs"
+    "webNavigation"
   ],
 
   "content_scripts": [{


### PR DESCRIPTION
Context https://expensify.slack.com/archives/C06N6E4RF/p1699992960443509

![image](https://github.com/Expensify/k2-extension/assets/521248/8f003d91-cd54-4bfa-9e58-03f34e66c037)

I think we don't need that permission because we are not using url, pendingUrl, title, or favIconUrl.