### PR TITLE
Show on the K2 dashboard when someone else is the issue owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#1.3.63
+- Allow for code owners to be assigned when there is only one person assigned
+- Show on the K2 dashboard if an issue has an owner, and you're not the owner
+
 #1.3.62
 - Design improvements for light and dark mode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #1.3.63
 - Allow for code owners to be assigned when there is only one person assigned
 - Show on the K2 dashboard if an issue has an owner, and you're not the owner
+- Add a filter for issues not owned by you
 
 #1.3.62
 - Design improvements for light and dark mode.

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 
   "name": "K2 for GitHub",
-  "version": "1.3.62",
+  "version": "1.3.63",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.62",
+  "version": "1.3.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.62",
+  "version": "1.3.63",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/component/list-item/ListItemIssue.js
+++ b/src/js/component/list-item/ListItemIssue.js
@@ -67,6 +67,11 @@ class ListItemIssue extends React.Component {
                         {'★ '}
                     </span>
                 )}
+                {this.issueHasOwner && !this.isCurrentUserOwner && (
+                    <span>
+                        {'☆ '}
+                    </span>
+                )}
                 <a
                     href={this.props.issue.url}
                     className={this.getClassName()}

--- a/src/js/component/panel/PanelIssues.js
+++ b/src/js/component/panel/PanelIssues.js
@@ -27,9 +27,14 @@ const propTypes = {
     /** If there are no issues to list in the panel, hide the panel entirely */
     hideOnEmpty: PropTypes.bool,
 
+    /** If the issue is on HOLD, hide it */
     hideIfHeld: PropTypes.bool,
 
+    /** If the issue is under review, hide it */
     hideIfUnderReview: PropTypes.bool,
+
+    /** If the issue is owned by someone else, hide it */
+    hideIfOwnedBySomeoneElse: PropTypes.bool,
 };
 const defaultProps = {
     filters: {
@@ -42,21 +47,27 @@ const defaultProps = {
     hideOnEmpty: false,
     hideIfHeld: false,
     hideIfUnderReview: false,
+    hideIfOwnedBySomeoneElse: false,
 };
 
 function PanelIssues(props) {
     let filteredData = props.data;
 
-    if (props.hideIfHeld || props.hideIfUnderReview) {
+    if (props.hideIfHeld || props.hideIfUnderReview || props.hideIfOwnedBySomeoneElse) {
         filteredData = _.filter(props.data, (item) => {
             const isHeld = item.title.toLowerCase().indexOf('[hold') > -1 ? ' hold' : '';
             const isUnderReview = _.find(item.labels, label => label.name.toLowerCase() === 'reviewing');
+            const isOwnedBySomeoneElse = item.issueHasOwner && !item.currentUserIsOwner;
 
             if (isHeld && props.hideIfHeld) {
                 return false;
             }
 
             if (isUnderReview && props.hideIfUnderReview) {
+                return false;
+            }
+
+            if (isOwnedBySomeoneElse && props.hideIfOwnedBySomeoneElse) {
                 return false;
             }
 

--- a/src/js/lib/pages/github/issue.js
+++ b/src/js/lib/pages/github/issue.js
@@ -74,12 +74,6 @@ const refreshAssignees = () => {
     // Always start by erasing whatever was drawn before (so it always starts from a clean slate)
     $('.js-issue-assignees .k2-element').remove();
 
-    // Do nothing if there is only one person assigned. Owners can only be set when there are
-    // multiple assignees
-    if ($('.js-issue-assignees > p > span').length <= 1) {
-        return;
-    }
-
     // Check if there is an owner for the issue
     const ghDescription = $('.comment-body').text();
     const regexResult = ghDescription.match(/Current Issue Owner:\s@(?<owner>\S+)/i);

--- a/src/js/lib/pages/github/issue.js
+++ b/src/js/lib/pages/github/issue.js
@@ -91,7 +91,7 @@ const refreshAssignees = () => {
         } else {
             $(el).append(`
                 <button type="button" class="Button flex-md-order-2 m-0 k2-element k2-button k2-button-make-owner" data-owner="${assignee}">
-                    ○
+                    ☆
                 </button>
             `);
         }

--- a/src/js/module/dashboard/Legend.js
+++ b/src/js/module/dashboard/Legend.js
@@ -46,6 +46,11 @@ function Legend() {
                 {' '}
                 Issue owner
             </div>
+            <div>
+                <span>☆</span>
+                {' '}
+                Issue is owned by someone else
+            </div>
             <div className="issue">
                 <sup>I</sup>
                 {' '}

--- a/src/js/module/dashboard/ListIssuesAssigned.js
+++ b/src/js/module/dashboard/ListIssuesAssigned.js
@@ -24,9 +24,11 @@ class ListIssuesAssigned extends React.Component {
 
         this.state = {shouldHideHeldIssues: false};
         this.state = {shouldHideUnderReviewIssues: false};
+        this.state = {shouldHideOwnedBySomeoneElseIssues: false};
         this.fetch = this.fetch.bind(this);
         this.toggleHeldFilter = this.toggleHeldFilter.bind(this);
         this.toggleUnderReviewFilter = this.toggleUnderReviewFilter.bind(this);
+        this.toggleOwnedBySomeoneElseFilter = this.toggleOwnedBySomeoneElseFilter.bind(this);
     }
 
     componentDidMount() {
@@ -54,6 +56,10 @@ class ListIssuesAssigned extends React.Component {
 
     toggleUnderReviewFilter() {
         this.setState(prevState => ({shouldHideUnderReviewIssues: !prevState.shouldHideUnderReviewIssues}));
+    }
+
+    toggleOwnedBySomeoneElseFilter() {
+        this.setState(prevState => ({shouldHideOwnedBySomeoneElseIssues: !prevState.shouldHideOwnedBySomeoneElseIssues}));
     }
 
     render() {
@@ -90,6 +96,12 @@ class ListIssuesAssigned extends React.Component {
                                 Under Review
                             </label>
                         </div>
+                        <div className="checkbox">
+                            <label>
+                                <input type="checkbox" name="shouldHideIfUnderReview" id="shouldHideIfUnderReview" onChange={this.toggleOwnedBySomeoneElseFilter} />
+                                Owned by Someone Else
+                            </label>
+                        </div>
                     </form>
                 </div>
                 <div className="d-flex flex-row">
@@ -100,6 +112,7 @@ class ListIssuesAssigned extends React.Component {
                             data={_.pick(this.props.issues, issue => _.findWhere(issue.labels, {name: 'Hourly'}))}
                             hideIfHeld={this.state.shouldHideHeldIssues}
                             hideIfUnderReview={this.state.shouldHideUnderReviewIssues}
+                            hideIfOwnedBySomeoneElse={this.state.shouldHideOwnedBySomeoneElseIssues}
                         />
                     </div>
                     <div className="col-3 pr-3">
@@ -109,6 +122,7 @@ class ListIssuesAssigned extends React.Component {
                             data={_.pick(this.props.issues, issue => _.findWhere(issue.labels, {name: 'Daily'}))}
                             hideIfHeld={this.state.shouldHideHeldIssues}
                             hideIfUnderReview={this.state.shouldHideUnderReviewIssues}
+                            hideIfOwnedBySomeoneElse={this.state.shouldHideOwnedBySomeoneElseIssues}
                         />
                     </div>
                     <div className="col-3 pr-3">
@@ -118,6 +132,7 @@ class ListIssuesAssigned extends React.Component {
                             data={_.pick(this.props.issues, issue => _.findWhere(issue.labels, {name: 'Weekly'}))}
                             hideIfHeld={this.state.shouldHideHeldIssues}
                             hideIfUnderReview={this.state.shouldHideUnderReviewIssues}
+                            hideIfOwnedBySomeoneElse={this.state.shouldHideOwnedBySomeoneElseIssues}
                         />
                     </div>
                     <div className="col-3">
@@ -127,6 +142,7 @@ class ListIssuesAssigned extends React.Component {
                             data={_.pick(this.props.issues, issue => _.findWhere(issue.labels, {name: 'Monthly'}))}
                             hideIfHeld={this.state.shouldHideHeldIssues}
                             hideIfUnderReview={this.state.shouldHideUnderReviewIssues}
+                            hideIfOwnedBySomeoneElse={this.state.shouldHideOwnedBySomeoneElseIssues}
                         />
                     </div>
                 </div>
@@ -139,6 +155,7 @@ class ListIssuesAssigned extends React.Component {
                         data={_.pick(this.props.issues, issue => _.intersection(_.map(issue.labels, label => label.name), ['Hourly', 'Daily', 'Weekly', 'Monthly']).length === 0)}
                         hideIfHeld={this.state.shouldHideHeldIssues}
                         hideIfUnderReview={this.state.shouldHideUnderReviewIssues}
+                        hideIfOwnedBySomeoneElse={this.state.shouldHideOwnedBySomeoneElseIssues}
                     />
                 </div>
             </div>


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/390841

# Tests
1. Have a test issue like https://github.com/Expensify/Expensify/issues/390830
2. Assign it only to yourself
3. Verify you can set yourself as the code owner and you can toggle it on and off
4. Assign the issue to one more person and make them the code owner
5. Refresh your K2 dashboard and verify the issue is shown with an empty star 
6. Check the filter to hide "Owned by Someone Else"
7. Verify that the issues with an empty star are no longer shown

![image](https://github.com/Expensify/k2-extension/assets/1228807/59e01d0d-0e3e-49c8-ac9f-88b3a2a2c1db)

![image](https://github.com/Expensify/k2-extension/assets/1228807/c0251f7f-1b1c-404c-90f5-5571f42f16d0)
