### PR TITLE
Updated K2 extension to Manifest V3

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "K2 for GitHub",
   "version": "1.3.64",
@@ -19,8 +19,11 @@
   },
 
   "permissions": [
-    "*://api.github.com/*",
     "webNavigation"
+  ],
+
+  "host_permissions": [
+      "*://api.github.com/*"
   ],
 
   "content_scripts": [{

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.64",
+  "version": "1.3.65",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -33,7 +33,7 @@
   }],
 
   "background": {
-    "persistent": false,
-    "scripts": ["events.js"]
+    "service_worker": "events.js",
+    "type": "module"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "k2-extension",
-      "version": "1.3.63",
+      "version": "1.3.64",
       "hasInstallScript": true,
       "dependencies": {
         "dotenv": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "k2-extension",
-  "version": "1.3.64",
+  "version": "1.3.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "k2-extension",
-      "version": "1.3.64",
+      "version": "1.3.65",
       "hasInstallScript": true,
       "dependencies": {
         "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.64",
+  "version": "1.3.65",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/Expensify/Expensify/issues/422655

Loading the plugin in Chrome after building produces no errors in console, which should be visible if there are any Manifest V3 incompatibilities. 

Tested as much as I could, but will appreciate another pair of eyes looking into this. Afterwards, we need to submit the beta to Google for review to see if it really passes Manifest V3 restrictions.

Migration steps checked out:
- [x] [Update the manifest.json file appropriately](https://developer.chrome.com/docs/extensions/develop/migrate/manifest) - URL permissions needed to be moved to host_permissions and manifest version incremented
- [x] [Replace callbacks with promises](https://developer.chrome.com/docs/extensions/develop/migrate/api-calls#replace-callbacks) - no API callbacks were made
- [x] [Double check we don't block any sites or web requests](https://developer.chrome.com/docs/extensions/develop/migrate/blocking-web-requests) - no requests are blocked
- [x] [Double check we aren't loading code (libraries, etc.) from elsewhere](https://developer.chrome.com/docs/extensions/develop/migrate/remote-hosted-code) - no remote code being loaded
- [x] [Migrate everything necessary out of the existing events.js and into a service worker](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers) - declared events.js as the service worker, I hope this is enough