### PR TITLE
Fixed manifest for Firefox, added linting and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,13 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - name: Checkout repository
+              uses: actions/checkout@v2
               with:
                   fetch-depth: 0
 
-            - uses: actions/cache@v2
+            - name: Add build cache
+              uses: actions/cache@v2
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -31,4 +33,8 @@ jobs:
                   max_attempts: 5
                   command: npm ci
 
-            - run: npx eslint --max-warnings=0 $(git diff --diff-filter=ACM --name-only origin/main '**/*.js' | xargs)
+            - name: Lint with ESLint
+              run: npx eslint --max-warnings=0 $(git diff --diff-filter=ACM --name-only origin/main '**/*.js' | xargs)
+            - name: Lint for Firefox
+              run: npm run lint:firefox
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.3.67
+- Added additional linting and CI for Firefox 
+
 #1.3.66
 - Added Firefox build script for Manifest V3 compatibility
 

--- a/assets/manifest-firefox.json
+++ b/assets/manifest-firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.66",
+  "version": "1.3.67",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/assets/manifest-firefox.json
+++ b/assets/manifest-firefox.json
@@ -6,9 +6,9 @@
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {
-    "gecko": {
-        "id": "ksv2@expensify.com",
-        "strict_min_version": "48.0"
+      "gecko": {
+          "id": "ksv2@expensify.com",
+          "strict_min_version": "112.0"
       }
   },
 

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.66",
+  "version": "1.3.67",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -5,13 +5,6 @@
   "version": "1.3.66",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
-  "browser_specific_settings": {
-    "gecko": {
-        "id": "ksv2@expensify.com",
-        "strict_min_version": "42.0"
-      }
-  },
-
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.66",
+  "version": "1.3.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.66",
+  "version": "1.3.67",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fixed problems with the FF extension by using the `web-ext` package from Mozilla, which helps with linting. 
Web-ext linting was also added as a step to GitHub actions, so we can be sure it's compatible with Firefox without having to first package and upload to addons.mozilla.org.