### PR TITLE
Fix extra padding on bullet lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.3.70
+- Fixed padding added to bullet lists in comments
+
 #1.3.69
 - Security fixes
 

--- a/assets/manifest-firefox.json
+++ b/assets/manifest-firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.69",
+  "version": "1.3.70",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.69",
+  "version": "1.3.70",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "k2-extension",
-  "version": "1.3.69",
+  "version": "1.3.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "k2-extension",
-      "version": "1.3.69",
+      "version": "1.3.70",
       "hasInstallScript": true,
       "dependencies": {
         "idb-keyval": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.69",
+  "version": "1.3.70",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -511,10 +511,6 @@ $color-dark-yellow: #DAA520;
   display: none;
 }
 
-.edit-comment-hide ul {
-  padding-left: 30px !important;
-}
-
 .btn-group-grid {
   display: flex;
   flex-flow: row wrap;


### PR DESCRIPTION
Removes extra padding that gets added to bulleted lists in comments because of a collision with one of our old styles.

| Before | After |
|--------|--------|
| ![Screenshot 2024-11-14 at 5 22 33 PM](https://github.com/user-attachments/assets/03d4bb0f-92c0-4d19-b581-eabbe65cebb9) | ![Screenshot 2024-11-14 at 5 22 49 PM](https://github.com/user-attachments/assets/d673d8f4-e390-4786-8fd5-dcbf9801fb86) |


