### PR TITLE
Add HotPick E/E issues to K2 + Shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.3.72
+- Included Expensify/Expensify Hot Pick issues to the section with the same name.
+
 #1.3.71
 - Removed the whats app quality section and replaced it with a hot pick section
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #1.3.72
 - Included Expensify/Expensify Hot Pick issues to the section with the same name.
+- Added `Hot Pick` label to the shortcuts right panel.
+- Removed `Ops` label from the shortcuts.
 
 #1.3.71
 - Removed the whats app quality section and replaced it with a hot pick section

--- a/assets/manifest-firefox.json
+++ b/assets/manifest-firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.71",
+  "version": "1.3.72",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.71",
+  "version": "1.3.72",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "k2-extension",
-  "version": "1.3.71",
+  "version": "1.3.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "k2-extension",
-      "version": "1.3.71",
+      "version": "1.3.72",
       "hasInstallScript": true,
       "dependencies": {
         "idb-keyval": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.71",
+  "version": "1.3.72",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -152,6 +152,7 @@ function getHotPickIssues() {
     query += ' state:open';
     query += ' type:issue';
     query += ' repo:Expensify/App';
+    query += ' repo:Expensify/Expensify';
     query += ' NOT hold in:title';
     query += ' label:\\"Hot Pick\\"';
 

--- a/src/js/module/K2pickerarea/K2PickerareaPicker.js
+++ b/src/js/module/K2pickerarea/K2PickerareaPicker.js
@@ -22,10 +22,6 @@ class K2PickerareaPicker extends React.Component {
                 className: `${defaultBtnClass} inactive k2-design`,
                 shortName: '🎨 Design',
             },
-            Ops: {
-                className: `${defaultBtnClass} inactive k2-ops`,
-                shortName: '💰 Ops',
-            },
             Infra: {
                 className: `${defaultBtnClass} inactive k2-infra`,
                 shortName: '🚨 Infra',

--- a/src/js/module/K2pickerarea/K2PickerareaPicker.js
+++ b/src/js/module/K2pickerarea/K2PickerareaPicker.js
@@ -15,7 +15,7 @@ class K2PickerareaPicker extends React.Component {
                 shortName: '💻 Engineering',
             },
             'Integration Server': {
-                className: `${defaultBtnClass} inactive k2-integration server tooltipped tooltipped-n`,
+                className: `${defaultBtnClass} inactive k2-integration-server tooltipped tooltipped-n`,
                 shortName: '📤 IS',
             },
             Design: {
@@ -28,11 +28,15 @@ class K2PickerareaPicker extends React.Component {
             },
             Infra: {
                 className: `${defaultBtnClass} inactive k2-infra`,
-                shortName: '🔥 Infra',
+                shortName: '🚨 Infra',
             },
             External: {
                 className: `${defaultBtnClass} inactive k2-external`,
                 shortName: '👥 External',
+            },
+            'Hot Pick': {
+                className: `${defaultBtnClass} inactive k2-hot-pick`,
+                shortName: '🔥 Hot Pick',
             },
         };
         // eslint-disable-next-line rulesdir/prefer-underscore-method


### PR DESCRIPTION
Besides the main changes for HotPick, I removed the `Ops` label because it hasn't been used in more than a year.

## Tests:

1. Run `npm run web`
2. Update your local extension in from `chrome://extension`
3. Reload the K2 dashboard
4. Verify Expensify/Expensify Hot Pick issues are shown:

![image](https://github.com/user-attachments/assets/80d2157c-896b-45d3-bc76-30181c0c0c5c)
![image](https://github.com/user-attachments/assets/57213414-6063-4de8-a49e-db86b3962163)

6. Open any issue, make sure the `Hot Pick` shortcut is shown in the right-hand menu:

![image](https://github.com/user-attachments/assets/27e49437-5ce1-41f1-8260-3c8f3768f256)

----------

Fixes: https://github.com/Expensify/Expensify/issues/453292