### PR TITLE
Move checkbox config to onyx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#1.3.74
+- Moved the previous query string params to Onyx
+
 #1.3.73
 - Added query string params to determine initial checked state for "on hold", "under review", and "owned by someone else" checkboxes
 

--- a/assets/manifest-firefox.json
+++ b/assets/manifest-firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.73",
+  "version": "1.3.74",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.3.73",
+  "version": "1.3.74",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.73",
+  "version": "1.3.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.3.73",
+  "version": "1.3.74",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {

--- a/src/js/ONYXKEYS.js
+++ b/src/js/ONYXKEYS.js
@@ -15,6 +15,7 @@ export default {
         DAILY_IMPROVEMENTS: 'issueDailyImprovements',
         ENGINEERING: 'issueEngineering',
         FILTER: 'issueFilter',
+        CHECKBOXES: 'issueCheckboxes',
         HOTPICKS: 'issueHotPicks',
     },
 

--- a/src/js/lib/actions/Issues.js
+++ b/src/js/lib/actions/Issues.js
@@ -138,6 +138,16 @@ function getEngineering() {
 }
 
 /**
+ * @param {Object} checkboxes
+ * @param {String} checkboxes.shouldHideOnHold
+ * @param {String} checkboxes.shouldHideUnderReview
+ * @param {String} checkboxes.shouldHideOwnedBySomeoneElse
+ */
+function saveCheckboxes(checkboxes) {
+    ReactNativeOnyx.merge(ONYXKEYS.ISSUES.CHECKBOXES, checkboxes);
+}
+
+/**
  * @param {Object} filters
  * @param {String} filters.milestone
  * @param {String} filters.improvement
@@ -161,5 +171,6 @@ export {
     getEngineering,
     getDailyImprovements,
     getHotPicks,
+    saveCheckboxes,
     saveFilters,
 };

--- a/src/js/lib/actions/Issues.js
+++ b/src/js/lib/actions/Issues.js
@@ -139,9 +139,9 @@ function getEngineering() {
 
 /**
  * @param {Object} checkboxes
- * @param {String} checkboxes.shouldHideOnHold
- * @param {String} checkboxes.shouldHideUnderReview
- * @param {String} checkboxes.shouldHideOwnedBySomeoneElse
+ * @param {String} [checkboxes.shouldHideOnHold]
+ * @param {String} [checkboxes.shouldHideUnderReview]
+ * @param {String} [checkboxes.shouldHideOwnedBySomeoneElse]
  */
 function saveCheckboxes(checkboxes) {
     ReactNativeOnyx.merge(ONYXKEYS.ISSUES.CHECKBOXES, checkboxes);

--- a/src/js/module/dashboard/ListIssuesAssigned.js
+++ b/src/js/module/dashboard/ListIssuesAssigned.js
@@ -13,19 +13,34 @@ const propTypes = {
 
     /** All the GH issues assigned to the current user */
     issues: PropTypes.objectOf(IssuePropTypes),
+
+    checkboxes: PropTypes.shape({
+        /** Should issues that are on HOLD be hidden? */
+        shouldHideOnHold: PropTypes.bool,
+
+        /** Should issues with "reviewing" label be hidden? */
+        shouldHideUnderReview: PropTypes.bool,
+
+        /** Should issues owned by someone else be hidden? */
+        shouldHideOwnedBySomeoneElse: PropTypes.bool,
+    }),
 };
 const defaultProps = {
     issues: null,
+    checkboxes: {
+        shouldHideOnHold: false,
+        shouldHideUnderReview: false,
+        shouldHideOwnedBySomeoneElse: false,
+    },
 };
 
 class ListIssuesAssigned extends React.Component {
     constructor(props) {
         super(props);
-        const params = new URLSearchParams(window.location.search);
         this.state = {
-            shouldHideHeldIssues: !!params.get('shouldHideOnHold'),
-            shouldHideUnderReviewIssues: !!params.get('shouldHideUnderReview'),
-            shouldHideOwnedBySomeoneElseIssues: !!params.get('shouldHideOwnedBySomeoneElse'),
+            shouldHideHeldIssues: props.checkboxes.shouldHideOnHold,
+            shouldHideUnderReviewIssues: props.checkboxes.shouldHideUnderReview,
+            shouldHideOwnedBySomeoneElseIssues: props.checkboxes.shouldHideOwnedBySomeoneElse,
         };
         this.fetch = this.fetch.bind(this);
         this.toggleHeldFilter = this.toggleHeldFilter.bind(this);
@@ -54,14 +69,17 @@ class ListIssuesAssigned extends React.Component {
 
     toggleHeldFilter() {
         this.setState(prevState => ({shouldHideHeldIssues: !prevState.shouldHideHeldIssues}));
+        Issues.saveCheckboxes({shouldHideOnHold: !this.state.shouldHideHeldIssues});
     }
 
     toggleUnderReviewFilter() {
         this.setState(prevState => ({shouldHideUnderReviewIssues: !prevState.shouldHideUnderReviewIssues}));
+        Issues.saveCheckboxes({shouldHideUnderReview: !this.state.shouldHideUnderReviewIssues});
     }
 
     toggleOwnedBySomeoneElseFilter() {
         this.setState(prevState => ({shouldHideOwnedBySomeoneElseIssues: !prevState.shouldHideOwnedBySomeoneElseIssues}));
+        Issues.saveCheckboxes({shouldHideOwnedBySomeoneElse: !this.state.shouldHideOwnedBySomeoneElseIssues});
     }
 
     render() {
@@ -189,5 +207,8 @@ ListIssuesAssigned.defaultProps = defaultProps;
 export default withOnyx({
     issues: {
         key: ONYXKEYS.ISSUES.ASSIGNED,
+    },
+    checkboxes: {
+        key: ONYXKEYS.ISSUES.CHECKBOXES,
     },
 })(ListIssuesAssigned);


### PR DESCRIPTION
cc @cead22 

This PR refactors https://github.com/Expensify/k2-extension/pull/220 to store the information in Onyx so the settings are automatically remembered.

# Tests
1. Go to the K2 dashboard
2. Check some of the checkbox filters for hiding specific issues
3. Refresh the page
4. Verify the same checkbox filters were remembered and applied to the dashboard