### PR TITLE
Use GH CLI to assign reviewer instead of melvin token

### DIFF
--- a/.github/workflows/snyk_pull_requests.yml
+++ b/.github/workflows/snyk_pull_requests.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign PullerBear for Snyk PR reviews
-        uses: nikosmoum/auto-assign-reviewer-team@v0.5
-        with:
-          teamName: "pullerbear"
-          githubToken: ${{ secrets.MELVIN_GH_TOKEN }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-team-reviewer "Expensify/pullerbear"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
No need to use a third party action and melvin's GH token when GH should be able to do this with the CLI and built in actions token.

Fixes https://github.com/Expensify/Expensify/issues/455566