### PR TITLE
Fixed cache step of lint GH action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Add build cache
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ~/.npm
                   key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Bumped the version to v4, as v2 cache is deprecated and the action is no longer running.