### PR TITLE
Bump version for prioritization fix on large lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#1.5.1
+- Fixed drag and drop prioritization for lists with 11+ items
+- Newly added, un-prioritized issues are now displayed at the top of the list to prompt users to prioritize them
+
 #1.5.0
 - Added drag and drop prioritization within each priority label list (Hourly, Daily, Weekly, Monthly)
 

--- a/assets/manifest-firefox.json
+++ b/assets/manifest-firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "browser_specific_settings": {

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
 
   "name": "K2 for GitHub",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Manage your Kernel Scheduling from directly inside GitHub",
 
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "k2-extension",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "k2-extension",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k2-extension",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A Chrome Extension for Kernel Schedule",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Follow up to this PR [Fix K2 prioritization for large lists](https://github.com/Expensify/k2-extension/pull/257#top) because I forgot to update the version.