### PR TITLE
chore: replace 'Travis' with 'Github Actions

### DIFF
--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -212,7 +212,7 @@ $color-dark-yellow: #DAA520;
     .issue, .panel-item-meta {
       color: $color-neutral-light !important;
     }
-    .travis-status, .mergeable-state {
+    .github-actions-status, .mergeable-state {
       color: color.mix($color-neutral-light, $color-dark-yellow, 75%) !important;
       &.success, &.MERGEABLE:not(.CHANGES_REQUESTED):not(.REVIEW_REQUIRED) {
         color: color.mix($color-neutral-light, $color-darker-green, 75%) !important;
@@ -321,7 +321,7 @@ $color-dark-yellow: #DAA520;
   }
 }
 
-.travis-status {
+.github-actions-status {
   color: $color-orange;
 
   &.success {

--- a/src/js/component/list-item/ListItemPull.js
+++ b/src/js/component/list-item/ListItemPull.js
@@ -96,8 +96,8 @@ function ListItemPull(props) {
                 </span>
 
                 {pr.checkConclusion && (
-                    <span className={`travis-status ${pr.checkConclusion}`}>
-                        Travis:
+                    <span className={`github-actions-status ${pr.checkConclusion}`}>
+                        Github Actions:
                         {' '}
                         {pr.checkConclusion}
                         ,


### PR DESCRIPTION
Just renaming the travis from the homepage to GH Actions as we are not using Jarvis anymore

## Example

<img width="1171" height="142" alt="image" src="https://github.com/user-attachments/assets/d08902e9-3f18-4e17-a83d-846529146cb5" />
