### PR TITLE
Fix HOLD merge button disabling broken by GitHub DOM changes

### DIFF
--- a/src/js/lib/pages/github/pr.js
+++ b/src/js/lib/pages/github/pr.js
@@ -55,7 +55,7 @@ const refreshSidebar = function () {
 };
 
 const refreshHold = function () {
-    const prTitle = $('.js-issue-title').text();
+    const prTitle = $('h1[data-component="PH_Title"] span.markdown-title').text();
 
     const isNewMergeUI = $('div[data-testid="mergebox-partial"]').length;
 
@@ -87,7 +87,7 @@ const refreshHold = function () {
     }
 
     if (prTitle.toLowerCase().indexOf('[hold') > -1 || prTitle.toLowerCase().indexOf('[wip') > -1) {
-        $('div[data-testid="mergebox-partial"] > div > div:last-of-type') // Entire PR merge section
+        $('div[data-testid="mergebox-border-container"]') // Entire PR merge section
             .removeClass('borderColor-success-emphasis');
         $('div[data-testid="mergebox-partial"] > div > div > div button').first() // Merge pull request button
             .css({backgroundColor: 'var(--bgColor-neutral-muted)', borderColor: 'var(--bgColor-neutral-muted)'})


### PR DESCRIPTION
## Problem                                                                                                          
  GitHub changed their DOM structure, breaking two selectors in `refreshHold()`:                                      
                                                                                                                      
  1. `.js-issue-title` no longer exists — `prTitle` was always an empty string, so the `[HOLD` check always failed    
  silently.                                                                                                           
  2. `div[data-testid="mergebox-partial"] > div > div:last-of-type` targeted the wrong element (the "Still in         
  progress" div instead of the border container).                                                                     
   
  Observed on: https://github.com/Expensify/Web-Expensify/pull/51995                                                  
                  
  Fixes https://github.com/Expensify/Expensify/issues/622438                                                          
                  
  ## Fix                                                                                                              
  - Replace `.js-issue-title` with `h1[data-component="PH_Title"] span.markdown-title`
  - Replace the fragile `:last-of-type` path with `div[data-testid="mergebox-border-container"]`                      
                                                                                                                      
  ## Testing                                                                                                          
  Opened a test PR with `[HOLD` in the title on a personal repo. Confirmed the merge button is now greyed out and     
  disabled, and the hold message displays correctly. 