### PR TITLE
Add new scope for issue timeline container

### DIFF
--- a/src/js/lib/autoLoadMoreComments.js
+++ b/src/js/lib/autoLoadMoreComments.js
@@ -8,6 +8,7 @@ const LOAD_MORE_TEXT = /^(load more|show\s+(\d+|hidden)\s+(hidden|earlier|more|p
 const SCOPES = [
     '.js-discussion',
     '[data-testid="issue-viewer-timeline"]',
+    '[data-testid="issue-timeline-container"]',
     '[data-testid="pull-request-timeline"]',
     '.js-resolvable-timeline-thread-container',
     '.review-thread-component',


### PR DESCRIPTION
Github sucks and has 420 variations of this same message apparently. I noticed it was not working on a page like [this one](https://github.com/Expensify/Expensify/issues/570926#issuecomment-4461714884).

I tested by loading that page and ensuring it was loading the comments