### PR TITLE
Add functionality to enable/disable

### DIFF
--- a/src/js/component/panel-title/Title.js
+++ b/src/js/component/panel-title/Title.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ReactNativeOnyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+import * as Preferences from '../../lib/actions/Preferences';
 
 const propTypes = {
     /** The text to display */
@@ -17,24 +20,51 @@ const defaultProps = {
     onOpenAll: null,
 };
 
-function Title(props) {
-    return (
-        <div>
-            <h3 className="panel-title panel-title-with-actions">
-                <span>{`${props.text} ${props.count !== null ? `(${props.count})` : ''}`}</span>
-                {props.onOpenAll && props.count > 0 && (
-                    <button
-                        type="button"
-                        className="btn btn-sm"
-                        onClick={props.onOpenAll}
-                        title={`Open all ${props.count} items in new tabs`}
-                    >
-                        Open All
-                    </button>
-                )}
-            </h3>
-        </div>
-    );
+class Title extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showOpenAllButtons: Preferences.getShowOpenAllButtons(),
+        };
+        this.onyxConnection = null;
+    }
+
+    componentDidMount() {
+        this.onyxConnection = ReactNativeOnyx.connect({
+            key: ONYXKEYS.PREFERENCES,
+            callback: () => {
+                this.setState({showOpenAllButtons: Preferences.getShowOpenAllButtons()});
+            },
+        });
+    }
+
+    componentWillUnmount() {
+        if (!this.onyxConnection) {
+            return;
+        }
+        ReactNativeOnyx.disconnect(this.onyxConnection);
+    }
+
+    render() {
+        const {text, count, onOpenAll} = this.props;
+        return (
+            <div>
+                <h3 className="panel-title panel-title-with-actions">
+                    <span>{`${text} ${count !== null ? `(${count})` : ''}`}</span>
+                    {onOpenAll && count > 0 && this.state.showOpenAllButtons && (
+                        <button
+                            type="button"
+                            className="btn btn-sm"
+                            onClick={onOpenAll}
+                            title={`Open all ${count} items in new tabs`}
+                        >
+                            Open All
+                        </button>
+                    )}
+                </h3>
+            </div>
+        );
+    }
 }
 
 Title.propTypes = propTypes;

--- a/src/js/lib/actions/Preferences.js
+++ b/src/js/lib/actions/Preferences.js
@@ -3,6 +3,8 @@ import ONYXKEYS from '../../ONYXKEYS';
 
 let ghToken;
 let useAbsoluteTimestamps;
+let autoLoadMoreComments;
+let showOpenAllButtons;
 ReactNativeOnyx.connect({
     key: ONYXKEYS.PREFERENCES,
     callback: (preferences) => {
@@ -13,6 +15,8 @@ ReactNativeOnyx.connect({
 
         ghToken = preferences.ghToken;
         useAbsoluteTimestamps = !!preferences.useAbsoluteTimestamps;
+        autoLoadMoreComments = preferences.autoLoadMoreComments;
+        showOpenAllButtons = preferences.showOpenAllButtons;
     },
 });
 
@@ -40,9 +44,39 @@ function setUseAbsoluteTimestamps(value) {
     ReactNativeOnyx.merge(ONYXKEYS.PREFERENCES, {useAbsoluteTimestamps: value});
 }
 
+// Defaults to true so users who haven't set the preference keep the original behaviour.
+function getAutoLoadMoreComments() {
+    return autoLoadMoreComments !== false;
+}
+
+/**
+ * @param {Boolean} value
+ */
+function setAutoLoadMoreComments(value) {
+    autoLoadMoreComments = value;
+    ReactNativeOnyx.merge(ONYXKEYS.PREFERENCES, {autoLoadMoreComments: value});
+}
+
+// Defaults to true so users who haven't set the preference keep the original behaviour.
+function getShowOpenAllButtons() {
+    return showOpenAllButtons !== false;
+}
+
+/**
+ * @param {Boolean} value
+ */
+function setShowOpenAllButtons(value) {
+    showOpenAllButtons = value;
+    ReactNativeOnyx.merge(ONYXKEYS.PREFERENCES, {showOpenAllButtons: value});
+}
+
 export {
     getGitHubToken,
     setGitHubToken,
     getUseAbsoluteTimestamps,
     setUseAbsoluteTimestamps,
+    getAutoLoadMoreComments,
+    setAutoLoadMoreComments,
+    getShowOpenAllButtons,
+    setShowOpenAllButtons,
 };

--- a/src/js/lib/autoLoadMoreComments.js
+++ b/src/js/lib/autoLoadMoreComments.js
@@ -1,4 +1,7 @@
 import $ from 'jquery';
+import ReactNativeOnyx from 'react-native-onyx';
+import ONYXKEYS from '../ONYXKEYS';
+import * as Preferences from './actions/Preferences';
 
 // Matches the visible text on every comment-pagination control we want to auto-click.
 // Anchored at the start of the trimmed text so we don't match buttons that merely contain
@@ -20,6 +23,7 @@ const clicked = new WeakSet();
 
 let observer = null;
 let scanScheduled = false;
+let preferenceSubscribed = false;
 
 function isVisible(el) {
     return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
@@ -62,13 +66,43 @@ function scheduleScan() {
     });
 }
 
-function initAutoLoadMoreComments() {
+function start() {
     if (observer) {
         return;
     }
     scheduleScan();
     observer = new MutationObserver(scheduleScan);
     observer.observe(document.body, {childList: true, subtree: true});
+}
+
+function stop() {
+    if (!observer) {
+        return;
+    }
+    observer.disconnect();
+    observer = null;
+}
+
+function initAutoLoadMoreComments() {
+    if (preferenceSubscribed) {
+        return;
+    }
+    preferenceSubscribed = true;
+
+    if (Preferences.getAutoLoadMoreComments()) {
+        start();
+    }
+
+    ReactNativeOnyx.connect({
+        key: ONYXKEYS.PREFERENCES,
+        callback: () => {
+            if (Preferences.getAutoLoadMoreComments()) {
+                start();
+            } else {
+                stop();
+            }
+        },
+    });
 }
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/js/lib/pages/github/issue.js
+++ b/src/js/lib/pages/github/issue.js
@@ -8,6 +8,7 @@ import K2pickerarea from '../../../module/K2pickerarea/K2pickerarea';
 import K2pickerType from '../../../module/K2pickertype/K2pickertype';
 import ToggleReview from '../../../module/ToggleReview/ToggleReview';
 import ToggleTimestamps from '../../../module/ToggleTimestamps/ToggleTimestamps';
+import ToggleAutoLoadMore from '../../../module/ToggleAutoLoadMore/ToggleAutoLoadMore';
 import K2comments from '../../../module/K2comments/K2comments';
 import K2previousissues from '../../../module/K2previousissues/K2previousissues';
 import ONYXKEYS from '../../../ONYXKEYS';
@@ -150,6 +151,19 @@ const refreshPicker = function () {
         }
     }
 
+    // Add auto-load-more toggle wrapper directly after the timestamp wrapper if it doesn't exist
+    if (!$('.k2autoloadmore-wrapper').length) {
+        const timestampWrapper = $('.k2toggletimestamps-wrapper');
+        if (timestampWrapper.length) {
+            timestampWrapper.after('<div class="discussion-sidebar-item js-discussion-sidebar-item k2autoloadmore-wrapper"></div>');
+        } else {
+            const sidebar = $('.discussion-sidebar, [role="complementary"]').first();
+            if (sidebar.length) {
+                sidebar.append('<div class="discussion-sidebar-item js-discussion-sidebar-item k2autoloadmore-wrapper"></div>');
+            }
+        }
+    }
+
     new K2picker().draw();
     new K2pickerType().draw();
     new K2pickerarea().draw();
@@ -161,6 +175,12 @@ const refreshPicker = function () {
     const timestampWrapper = $('.k2toggletimestamps-wrapper');
     if (timestampWrapper.length && timestampWrapper.children().length === 0) {
         new ToggleTimestamps().draw();
+    }
+
+    // Draw auto-load-more toggle if wrapper exists and is empty
+    const autoLoadMoreWrapper = $('.k2autoloadmore-wrapper');
+    if (autoLoadMoreWrapper.length && autoLoadMoreWrapper.children().length === 0) {
+        new ToggleAutoLoadMore().draw();
     }
 };
 

--- a/src/js/lib/pages/github/pr.js
+++ b/src/js/lib/pages/github/pr.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import Base from './_base';
 import ToggleTimestamps from '../../../module/ToggleTimestamps/ToggleTimestamps';
+import ToggleAutoLoadMore from '../../../module/ToggleAutoLoadMore/ToggleAutoLoadMore';
 import * as autoLoadMoreComments from '../../autoLoadMoreComments';
 
 /**
@@ -24,35 +25,42 @@ const renderReplaceChecklistButton = () => {
 };
 
 const refreshSidebar = function () {
-    // Add the timestamp toggle wrapper to the DOM if it doesn't exist
-    if ($('.k2toggletimestamps-wrapper').length) {
-        // Draw the toggle if wrapper exists but is empty
-        const wrapper = $('.k2toggletimestamps-wrapper');
-        if (wrapper.children().length === 0) {
-            new ToggleTimestamps().draw();
-        }
-        return;
-    }
-
-    // Add timestamp toggle wrapper at the bottom of the sidebar
-    const lastSidebarItem = $('.discussion-sidebar-item').last();
-    if (lastSidebarItem.length) {
-        lastSidebarItem.after('<div class="discussion-sidebar-item js-discussion-sidebar-item k2toggletimestamps-wrapper"></div>');
-    } else {
-        // Fallback: append to sidebar container
-        const sidebar = $('.discussion-sidebar, [role="complementary"], .Layout-sidebar').first();
-        if (sidebar.length) {
-            sidebar.append('<div class="discussion-sidebar-item js-discussion-sidebar-item k2toggletimestamps-wrapper"></div>');
+    // Add the timestamp toggle wrapper at the bottom of the sidebar if it doesn't exist
+    if (!$('.k2toggletimestamps-wrapper').length) {
+        const lastSidebarItem = $('.discussion-sidebar-item').last();
+        if (lastSidebarItem.length) {
+            lastSidebarItem.after('<div class="discussion-sidebar-item js-discussion-sidebar-item k2toggletimestamps-wrapper"></div>');
+        } else {
+            const sidebar = $('.discussion-sidebar, [role="complementary"], .Layout-sidebar').first();
+            if (sidebar.length) {
+                sidebar.append('<div class="discussion-sidebar-item js-discussion-sidebar-item k2toggletimestamps-wrapper"></div>');
+            }
         }
     }
 
-    // Draw the timestamp toggle if the wrapper exists and is empty
-    const wrapper = $('.k2toggletimestamps-wrapper');
-    if (!wrapper.length || wrapper.children().length > 0) {
-        return;
+    // Add the auto-load-more toggle wrapper directly after the timestamp wrapper if it doesn't exist
+    if (!$('.k2autoloadmore-wrapper').length) {
+        const timestampWrapper = $('.k2toggletimestamps-wrapper');
+        if (timestampWrapper.length) {
+            timestampWrapper.after('<div class="discussion-sidebar-item js-discussion-sidebar-item k2autoloadmore-wrapper"></div>');
+        } else {
+            const sidebar = $('.discussion-sidebar, [role="complementary"], .Layout-sidebar').first();
+            if (sidebar.length) {
+                sidebar.append('<div class="discussion-sidebar-item js-discussion-sidebar-item k2autoloadmore-wrapper"></div>');
+            }
+        }
     }
 
-    new ToggleTimestamps().draw();
+    // Draw each toggle if its wrapper exists and is empty
+    const timestampWrapper = $('.k2toggletimestamps-wrapper');
+    if (timestampWrapper.length && timestampWrapper.children().length === 0) {
+        new ToggleTimestamps().draw();
+    }
+
+    const autoLoadMoreWrapper = $('.k2autoloadmore-wrapper');
+    if (autoLoadMoreWrapper.length && autoLoadMoreWrapper.children().length === 0) {
+        new ToggleAutoLoadMore().draw();
+    }
 };
 
 const refreshHold = function () {

--- a/src/js/module/ToggleAutoLoadMore/Toggle.js
+++ b/src/js/module/ToggleAutoLoadMore/Toggle.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import ReactNativeOnyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+import * as Preferences from '../../lib/actions/Preferences';
+
+const defaultBtnClass = 'btn btn-sm';
+
+class Toggle extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            autoLoadMoreComments: Preferences.getAutoLoadMoreComments(),
+        };
+        this.onyxConnection = null;
+    }
+
+    componentDidMount() {
+        this.onyxConnection = ReactNativeOnyx.connect({
+            key: ONYXKEYS.PREFERENCES,
+            callback: () => {
+                this.setState({autoLoadMoreComments: Preferences.getAutoLoadMoreComments()});
+            },
+        });
+    }
+
+    componentWillUnmount() {
+        if (!this.onyxConnection) {
+            return;
+        }
+        ReactNativeOnyx.disconnect(this.onyxConnection);
+    }
+
+    handleToggle() {
+        this.setState((prevState) => {
+            const newValue = !prevState.autoLoadMoreComments;
+            Preferences.setAutoLoadMoreComments(newValue);
+            return {autoLoadMoreComments: newValue};
+        });
+    }
+
+    render() {
+        return (
+            <div style={{width: '100%'}}>
+                <button
+                    type="button"
+                    className={this.state.autoLoadMoreComments
+                        ? `${defaultBtnClass} k2-auto-load-more selected`
+                        : `${defaultBtnClass} k2-auto-load-more`}
+                    onClick={() => this.handleToggle()}
+                    style={{width: '100%'}}
+                >
+                    {this.state.autoLoadMoreComments
+                        ? 'Auto-load comments: On'
+                        : 'Auto-load comments: Off'}
+                </button>
+            </div>
+        );
+    }
+}
+
+export default Toggle;
+
+// vim: set ts=4 sw=4 et:

--- a/src/js/module/ToggleAutoLoadMore/ToggleAutoLoadMore.js
+++ b/src/js/module/ToggleAutoLoadMore/ToggleAutoLoadMore.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+import Toggle from './Toggle';
+
+export default function () {
+    return {
+        draw() {
+            const root = createRoot(document.getElementsByClassName('k2autoloadmore-wrapper')[0]);
+            root.render(<Toggle />);
+        },
+    };
+}
+
+// vim: set ts=4 sw=4 et:

--- a/src/js/module/ToggleOpenAll/Toggle.js
+++ b/src/js/module/ToggleOpenAll/Toggle.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import ReactNativeOnyx from 'react-native-onyx';
+import ONYXKEYS from '../../ONYXKEYS';
+import * as Preferences from '../../lib/actions/Preferences';
+
+const defaultBtnClass = 'btn btn-sm';
+
+class Toggle extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showOpenAllButtons: Preferences.getShowOpenAllButtons(),
+        };
+        this.onyxConnection = null;
+    }
+
+    componentDidMount() {
+        this.onyxConnection = ReactNativeOnyx.connect({
+            key: ONYXKEYS.PREFERENCES,
+            callback: () => {
+                this.setState({showOpenAllButtons: Preferences.getShowOpenAllButtons()});
+            },
+        });
+    }
+
+    componentWillUnmount() {
+        if (!this.onyxConnection) {
+            return;
+        }
+        ReactNativeOnyx.disconnect(this.onyxConnection);
+    }
+
+    handleToggle() {
+        this.setState((prevState) => {
+            const newValue = !prevState.showOpenAllButtons;
+            Preferences.setShowOpenAllButtons(newValue);
+            return {showOpenAllButtons: newValue};
+        });
+    }
+
+    render() {
+        return (
+            <div style={{width: '100%', marginTop: '4px'}}>
+                <button
+                    type="button"
+                    className={this.state.showOpenAllButtons
+                        ? `${defaultBtnClass} k2-show-open-all selected`
+                        : `${defaultBtnClass} k2-show-open-all`}
+                    onClick={() => this.handleToggle()}
+                    style={{width: '100%'}}
+                >
+                    {this.state.showOpenAllButtons
+                        ? 'Open All buttons: On'
+                        : 'Open All buttons: Off'}
+                </button>
+            </div>
+        );
+    }
+}
+
+export default Toggle;
+
+// vim: set ts=4 sw=4 et:

--- a/src/js/module/dashboard/Legend.js
+++ b/src/js/module/dashboard/Legend.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactNativeOnyx from 'react-native-onyx';
 import * as Preferences from '../../lib/actions/Preferences';
+import ToggleOpenAll from '../ToggleOpenAll/Toggle';
 
 function Legend() {
     function signOut() {
@@ -42,6 +43,8 @@ function Legend() {
             >
                 New /app Issue
             </a>
+
+            <ToggleOpenAll />
 
             <br />
             <div className="issue reviewing">Under Review</div>


### PR DESCRIPTION
Adds two new user preferences for toggling existing K2 features on or off. Both default to on so existing users see no behaviour change.

- Auto-clicking GitHub's "Load more" buttons on issue/PR pages.
- The "Open All" buttons on dashboard panel headers.

The auto-load-more toggle lives in the issue/PR sidebar under the existing "Show/Hide Timestamps" toggle, and the Open All toggle lives on the K2 dashboard inside Legend.

Implementation notes:
- New preference helpers `get/setAutoLoadMoreComments` and `get/setShowOpenAllButtons` in `Preferences.js`, both treating an unset value as true.
- `autoLoadMoreComments.js` was refactored into `start` / `stop` / `initAutoLoadMoreComments`. The init subscribes to Onyx `PREFERENCES`, so flipping the toggle starts/stops the `MutationObserver` live without a page reload.
- The shared `Title` component (used by every dashboard panel) now subscribes to Onyx itself and gates the `Open All` button on `showOpenAllButtons`, so no consumer needed to change.
  - `pr.js refreshSidebar` was slightly restructured to support multiple toggle wrappers — the previous early-return-after-timestamp-wrapper flow couldn't accommodate a second sibling wrapper.

<img width="1246" height="340" alt="image" src="https://github.com/user-attachments/assets/dfdbaa53-c935-47f0-86bd-c6d92168f619" />

<img width="1492" height="836" alt="image" src="https://github.com/user-attachments/assets/fa0492ea-f511-4b99-8740-7202ba15124d" />
