### PR TITLE
Fix GitHub repository search

### DIFF
--- a/src/js/lib/pages/github/all.js
+++ b/src/js/lib/pages/github/all.js
@@ -1,6 +1,4 @@
-import $ from 'jquery';
 import Base from './_base';
-import k2Button from '../../../template/button.github.k2.html';
 
 /**
  * This class manages the things that happen on *every* GitHub page. All it's doing is adding links to the
@@ -19,31 +17,6 @@ export default function () {
      * Add buttons to the page and setup the event handler
      */
     AllPages.setup = function () {
-        // Hardcode because it doesn't change, and depending on GitHub markup means
-        // it breaks every so often
-        const currentUrl = '/Expensify/Expensify';
-
-        // Insert K2 button after the Pull requests tab, retrying if the nav hasn't rendered yet
-        if (!$('li.k2-extension').length) {
-            const pullsTab = $('nav[aria-label="Repository"] a[href*="/pulls"]').closest('li');
-            if (pullsTab.length) {
-                pullsTab.after(k2Button({url: currentUrl}));
-            } else {
-                let retries = 0;
-                const interval = setInterval(() => {
-                    if ($('li.k2-extension').length || ++retries >= 10) {
-                        clearInterval(interval);
-                        return;
-                    }
-                    const tab = $('nav[aria-label="Repository"] a[href*="/pulls"]').closest('li');
-                    if (tab.length) {
-                        tab.after(k2Button({url: currentUrl}));
-                        clearInterval(interval);
-                    }
-                }, 100);
-            }
-        }
-
         // Set up timestamp format conversion
         setTimeout(() => AllPages.applyTimestampFormat(), 500);
         setInterval(() => AllPages.applyTimestampFormat(), 5000);


### PR DESCRIPTION
Tested by reproducing on all the pages below on main, and by confirming it worked on this branch
- https://github.com/Expensify/Expensify/
- https://github.com/Expensify/Web-Expensify/
- https://github.com/expensify/k2-extension
- https://github.com/Expensify/Expensify/issues/665690

I also confirmed on main that the K2 tab wasn't showing. It was being added and then quickly removed -- at least on chrome. I'll follow up with a fix for the tab, but let's get this one out since it affects SRAMs