### PR TITLE
Bring back K2 tab

### DIFF
--- a/src/css/content.scss
+++ b/src/css/content.scss
@@ -743,12 +743,20 @@ $color-dark-yellow: #DAA520;
 li.k2-extension {
     display: flex;
     align-items: center;
+    list-style: none;
+}
+
+// Prevent the isolated K2 tab from covering GitHub's next tab.
+nav[aria-label="Repository"] a[href*="/pulls"] {
+    margin-right: 48px;
 }
 
 .k2-nav-link {
     display: flex;
     align-items: center;
-    padding: 8px 16px;
+    box-sizing: border-box;
+    height: 100%;
+    padding: 0 8px;
     font-size: 14px;
     font-weight: 400;
     line-height: 1.5;

--- a/src/js/lib/pages/github/all.js
+++ b/src/js/lib/pages/github/all.js
@@ -19,30 +19,40 @@ export default function () {
      * Add buttons to the page and setup the event handler
      */
     AllPages.setup = function () {
-        // Hardcode because it doesn't change, and depending on GitHub markup means
-        // it breaks every so often
-        const currentUrl = '/Expensify/Expensify';
+        let k2Tab = $('li.k2-extension');
 
-        // Insert K2 button after the Pull requests tab, retrying if the nav hasn't rendered yet
-        if (!$('li.k2-extension').length) {
-            const pullsTab = $('nav[aria-label="Repository"] a[href*="/pulls"]').closest('li');
-            if (pullsTab.length) {
-                pullsTab.after(k2Button({url: currentUrl}));
-            } else {
-                let retries = 0;
-                const interval = setInterval(() => {
-                    if ($('li.k2-extension').length || ++retries >= 10) {
-                        clearInterval(interval);
-                        return;
-                    }
-                    const tab = $('nav[aria-label="Repository"] a[href*="/pulls"]').closest('li');
-                    if (tab.length) {
-                        tab.after(k2Button({url: currentUrl}));
-                        clearInterval(interval);
-                    }
-                }, 100);
-            }
+        if (!k2Tab.length) {
+            // Keep the K2 tab outside GitHub's managed list because inserting it into that list breaks search.
+            $('body').append(k2Button({url: '/Expensify/Expensify'}));
+            k2Tab = $('li.k2-extension');
         }
+
+        const positionK2Tab = () => {
+            const pullsTab = $('nav[aria-label="Repository"] a[href*="/pulls"]').first();
+
+            if (!pullsTab.length) {
+                k2Tab.hide();
+                return;
+            }
+
+            // Use the Pull requests position so the isolated K2 tab looks like part of GitHub's tab list.
+            const rectangle = pullsTab[0].getBoundingClientRect();
+            k2Tab.css({
+                display: 'flex',
+                position: 'fixed',
+                top: rectangle.top,
+                left: rectangle.right + 8,
+                height: rectangle.height,
+                zIndex: 1000,
+            });
+        };
+
+        positionK2Tab();
+
+        // Keep the isolated tab aligned when the window moves GitHub's tab list.
+        $(window)
+            .off('resize.k2-extension scroll.k2-extension')
+            .on('resize.k2-extension scroll.k2-extension', positionK2Tab);
 
         // Set up timestamp format conversion
         setTimeout(() => AllPages.applyTimestampFormat(), 500);


### PR DESCRIPTION
- Tested by confirming I couldn't see the K2 tab on main, and that I can see it with this change. 
- I confirmed clicking the tab takes you to https://github.com/Expensify/Expensify#k2
- I also tested the search bar by clicking on it, and by hitting `/`, and doing a search

<img width="507" height="107" alt="image" src="https://github.com/user-attachments/assets/a611c95c-2eb7-45fe-9c3f-acfc550d38e3" />


Related https://github.com/Expensify/Expensify/issues/665690