### PR TITLE
Ignore peer review check and show pending status for running checks

### DIFF
--- a/src/js/lib/actions/PullRequests.js
+++ b/src/js/lib/actions/PullRequests.js
@@ -4,12 +4,9 @@ import * as API from '../api';
 import ONYXKEYS from '../../ONYXKEYS';
 import ActionThrottle from '../ActionThrottle';
 
-// Check runs whose results should not affect the overall check conclusion shown for a PR,
-// as long as the PR has a human reviewer (a pending review request or a submitted review,
-// excluding bots like github-actions[bot]). "Check independent approval" (from the "Verify
-// peer review" workflow) fails until a peer review happens, which is not a CI failure the
-// author needs to act on. A PR with no human reviewer has nobody lined up to review it, so
-// the failure stays visible as a prompt to find one.
+// Check runs whose results should not affect the overall check conclusion shown for a PR.
+// "Check independent approval" (from the "Verify peer review" workflow) fails until a peer
+// review happens, which is not a CI failure the author needs to act on.
 const IGNORED_CHECK_RUN_NAMES = ['Check independent approval'];
 
 function getChecks(prs, onyxKey) {
@@ -19,14 +16,12 @@ function getChecks(prs, onyxKey) {
                 if (!response.data.check_runs || !response.data.check_runs.length) {
                     return;
                 }
-                const hasHumanReviewer = _.any(pr.reviewRequests.nodes, request => request.requestedReviewer && request.requestedReviewer.type !== 'Bot')
-                    || _.any(pr.reviews.nodes, review => review.author && review.author.type !== 'Bot');
                 ReactNativeOnyx.merge(onyxKey, {
                     [pr.id]: {
                         checkConclusion: _.reduce(
                             response.data.check_runs,
                             (previousValue, currentValue) => {
-                                if (hasHumanReviewer && _.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
+                                if (_.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
                                     return previousValue;
                                 }
 

--- a/src/js/lib/actions/PullRequests.js
+++ b/src/js/lib/actions/PullRequests.js
@@ -4,9 +4,11 @@ import * as API from '../api';
 import ONYXKEYS from '../../ONYXKEYS';
 import ActionThrottle from '../ActionThrottle';
 
-// Check runs whose results should not affect the overall check conclusion shown for a PR.
-// "Check independent approval" (from the "Verify peer review" workflow) fails until a peer
-// review happens, which is not a CI failure the author needs to act on.
+// Check runs whose results should not affect the overall check conclusion shown for a PR,
+// as long as the PR has an assignee. "Check independent approval" (from the "Verify peer
+// review" workflow) fails until a peer review happens, which is not a CI failure the author
+// needs to act on. A PR with no assignee has nobody lined up to review it, so the failure
+// stays visible as a prompt to find one.
 const IGNORED_CHECK_RUN_NAMES = ['Check independent approval'];
 
 function getChecks(prs, onyxKey) {
@@ -21,7 +23,7 @@ function getChecks(prs, onyxKey) {
                         checkConclusion: _.reduce(
                             response.data.check_runs,
                             (previousValue, currentValue) => {
-                                if (_.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
+                                if (pr.assignees.nodes.length > 0 && _.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
                                     return previousValue;
                                 }
 

--- a/src/js/lib/actions/PullRequests.js
+++ b/src/js/lib/actions/PullRequests.js
@@ -4,6 +4,11 @@ import * as API from '../api';
 import ONYXKEYS from '../../ONYXKEYS';
 import ActionThrottle from '../ActionThrottle';
 
+// Check runs whose results should not affect the overall check conclusion shown for a PR.
+// "Check independent approval" (from the "Verify peer review" workflow) fails until a peer
+// review happens, which is not a CI failure the author needs to act on.
+const IGNORED_CHECK_RUN_NAMES = ['Check independent approval'];
+
 function getChecks(prs, onyxKey) {
     const checkRunPromises = _.reduce(prs, (finalPromiseArray, pr) => {
         finalPromiseArray.push(
@@ -16,11 +21,21 @@ function getChecks(prs, onyxKey) {
                         checkConclusion: _.reduce(
                             response.data.check_runs,
                             (previousValue, currentValue) => {
+                                if (_.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
+                                    return previousValue;
+                                }
+
                                 const conclusion = currentValue.conclusion;
 
                                 // If any check runs are failing, mark it failed
                                 if (conclusion === 'failure' || previousValue === 'failure') {
                                     return 'failure';
+                                }
+
+                                // Check runs only get a conclusion once they complete, so any run that isn't
+                                // completed yet means the overall result is still pending
+                                if (currentValue.status !== 'completed' || previousValue === 'pending') {
+                                    return 'pending';
                                 }
 
                                 // If the current check run is successful, mark it success. If the previous one is

--- a/src/js/lib/actions/PullRequests.js
+++ b/src/js/lib/actions/PullRequests.js
@@ -5,10 +5,11 @@ import ONYXKEYS from '../../ONYXKEYS';
 import ActionThrottle from '../ActionThrottle';
 
 // Check runs whose results should not affect the overall check conclusion shown for a PR,
-// as long as the PR has a reviewer (a pending review request or a submitted review).
-// "Check independent approval" (from the "Verify peer review" workflow) fails until a peer
-// review happens, which is not a CI failure the author needs to act on. A PR with no reviewer
-// has nobody lined up to review it, so the failure stays visible as a prompt to find one.
+// as long as the PR has a human reviewer (a pending review request or a submitted review,
+// excluding bots like github-actions[bot]). "Check independent approval" (from the "Verify
+// peer review" workflow) fails until a peer review happens, which is not a CI failure the
+// author needs to act on. A PR with no human reviewer has nobody lined up to review it, so
+// the failure stays visible as a prompt to find one.
 const IGNORED_CHECK_RUN_NAMES = ['Check independent approval'];
 
 function getChecks(prs, onyxKey) {
@@ -18,13 +19,14 @@ function getChecks(prs, onyxKey) {
                 if (!response.data.check_runs || !response.data.check_runs.length) {
                     return;
                 }
-                const hasReviewer = pr.reviewRequests.totalCount > 0 || pr.reviews.totalCount > 0;
+                const hasHumanReviewer = _.any(pr.reviewRequests.nodes, request => request.requestedReviewer && request.requestedReviewer.type !== 'Bot')
+                    || _.any(pr.reviews.nodes, review => review.author && review.author.type !== 'Bot');
                 ReactNativeOnyx.merge(onyxKey, {
                     [pr.id]: {
                         checkConclusion: _.reduce(
                             response.data.check_runs,
                             (previousValue, currentValue) => {
-                                if (hasReviewer && _.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
+                                if (hasHumanReviewer && _.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
                                     return previousValue;
                                 }
 

--- a/src/js/lib/actions/PullRequests.js
+++ b/src/js/lib/actions/PullRequests.js
@@ -5,10 +5,10 @@ import ONYXKEYS from '../../ONYXKEYS';
 import ActionThrottle from '../ActionThrottle';
 
 // Check runs whose results should not affect the overall check conclusion shown for a PR,
-// as long as the PR has an assignee. "Check independent approval" (from the "Verify peer
-// review" workflow) fails until a peer review happens, which is not a CI failure the author
-// needs to act on. A PR with no assignee has nobody lined up to review it, so the failure
-// stays visible as a prompt to find one.
+// as long as the PR has a reviewer (a pending review request or a submitted review).
+// "Check independent approval" (from the "Verify peer review" workflow) fails until a peer
+// review happens, which is not a CI failure the author needs to act on. A PR with no reviewer
+// has nobody lined up to review it, so the failure stays visible as a prompt to find one.
 const IGNORED_CHECK_RUN_NAMES = ['Check independent approval'];
 
 function getChecks(prs, onyxKey) {
@@ -18,12 +18,13 @@ function getChecks(prs, onyxKey) {
                 if (!response.data.check_runs || !response.data.check_runs.length) {
                     return;
                 }
+                const hasReviewer = pr.reviewRequests.totalCount > 0 || pr.reviews.totalCount > 0;
                 ReactNativeOnyx.merge(onyxKey, {
                     [pr.id]: {
                         checkConclusion: _.reduce(
                             response.data.check_runs,
                             (previousValue, currentValue) => {
-                                if (pr.assignees.nodes.length > 0 && _.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
+                                if (hasReviewer && _.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
                                     return previousValue;
                                 }
 

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -244,6 +244,9 @@ query {
                 reviews {
                     totalCount
                 }
+                reviewRequests {
+                    totalCount
+                }
             }
         }
     }

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -241,20 +241,8 @@ query {
                 repository {
                     name
                 }
-                reviews(first: 100) {
+                reviews {
                     totalCount
-                    nodes {
-                        author {
-                            type: __typename
-                        }
-                    }
-                }
-                reviewRequests(first: 100) {
-                    nodes {
-                        requestedReviewer {
-                            type: __typename
-                        }
-                    }
                 }
             }
         }

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -241,11 +241,20 @@ query {
                 repository {
                     name
                 }
-                reviews {
+                reviews(first: 100) {
                     totalCount
+                    nodes {
+                        author {
+                            type: __typename
+                        }
+                    }
                 }
-                reviewRequests {
-                    totalCount
+                reviewRequests(first: 100) {
+                    nodes {
+                        requestedReviewer {
+                            type: __typename
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/668743

### Problem

The `Github Actions:` status shown on PR list items had two issues:

1. PRs failing only the "Verify peer review" workflow (its `Check independent approval` job) showed `Github Actions: failure`. That check fails by design until a peer review happens, so it's noise for the author — not a CI failure to act on.
2. PRs with checks still running showed `Github Actions: success` as soon as any single check completed successfully. Check runs only get a `conclusion` once they complete, so in-progress runs (`conclusion: null`) were silently skipped by the reducer.

### Solution

In the check-run conclusion reducer (`src/js/lib/actions/PullRequests.js`):

- Skip check runs listed in a new `IGNORED_CHECK_RUN_NAMES` constant, currently just `Check independent approval`, so that check never affects the overall conclusion.
- Return a new `pending` conclusion when any check run has `status !== 'completed'`. Priority is now: `failure` > `pending` > `success` > `skipped` > `unknown`. No CSS change needed — non-success/failure statuses already render in the default orange.

### Tests

1. Load the unpacked extension from `dist/` after `npm run build`.
2. Open a K2 view (e.g. https://github.com/Expensify/Expensify#k2) and find the "Your Pull Requests" section.
3. Verify a PR whose only failing check is `Check independent approval` (e.g. a PR failing only the "Verify peer review" workflow) shows `Github Actions: success` in green.
4. Push a commit to a PR so its checks re-run, and verify the row shows `Github Actions: pending` in orange while checks are running.
5. Verify a PR with a genuinely failing check still shows `Github Actions: failure` in red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
