### PR TITLE
Show a commit as passing when peer review is its only failing check

### DIFF
--- a/src/js/CONST.js
+++ b/src/js/CONST.js
@@ -6,4 +6,10 @@ export default {
     // "Check independent approval" (from the "Verify peer review" workflow) fails until a peer review
     // happens, which is not a CI failure the author needs to act on.
     IGNORED_CHECK_RUN_NAMES: ['Check independent approval'],
+
+    // A ruleset-required workflow run keeps the repository the workflow came from in its resource path,
+    // e.g. /Expensify/App/actions/workflows/required/Expensify/GitHub-Actions/.github/workflows/...
+    // That is the part of the run a PR author cannot reproduce from a workflow file on their own branch,
+    // so it is what tells a real peer review check apart from a job that merely shares its name.
+    PEER_REVIEW_WORKFLOW_PATH: 'required/Expensify/GitHub-Actions/.github/workflows/verifyPeerReview.yml',
 };

--- a/src/js/CONST.js
+++ b/src/js/CONST.js
@@ -1,0 +1,9 @@
+/**
+ * This is a file containing constants shared across the extension
+ */
+export default {
+    // Check runs whose results should not affect the overall check conclusion shown for a commit or a PR.
+    // "Check independent approval" (from the "Verify peer review" workflow) fails until a peer review
+    // happens, which is not a CI failure the author needs to act on.
+    IGNORED_CHECK_RUN_NAMES: ['Check independent approval'],
+};

--- a/src/js/lib/actions/PullRequests.js
+++ b/src/js/lib/actions/PullRequests.js
@@ -2,12 +2,8 @@ import _ from 'underscore';
 import ReactNativeOnyx from 'react-native-onyx';
 import * as API from '../api';
 import ONYXKEYS from '../../ONYXKEYS';
+import CONST from '../../CONST';
 import ActionThrottle from '../ActionThrottle';
-
-// Check runs whose results should not affect the overall check conclusion shown for a PR.
-// "Check independent approval" (from the "Verify peer review" workflow) fails until a peer
-// review happens, which is not a CI failure the author needs to act on.
-const IGNORED_CHECK_RUN_NAMES = ['Check independent approval'];
 
 function getChecks(prs, onyxKey) {
     const checkRunPromises = _.reduce(prs, (finalPromiseArray, pr) => {
@@ -21,7 +17,7 @@ function getChecks(prs, onyxKey) {
                         checkConclusion: _.reduce(
                             response.data.check_runs,
                             (previousValue, currentValue) => {
-                                if (_.contains(IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
+                                if (_.contains(CONST.IGNORED_CHECK_RUN_NAMES, currentValue.name)) {
                                     return previousValue;
                                 }
 

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -292,6 +292,13 @@ query($owner:String!, $repo:String!, $oid:GitObjectID!, $cursor:String) {
                                 name
                                 status
                                 conclusion
+                                checkSuite {
+                                    workflowRun {
+                                        workflow {
+                                            resourcePath
+                                        }
+                                    }
+                                }
                             }
                             ... on StatusContext {
                                 context
@@ -315,10 +322,15 @@ query($owner:String!, $repo:String!, $oid:GitObjectID!, $cursor:String) {
             owner, repo, oid, cursor,
         });
 
-        // A commit that has no checks at all has a null rollup
         const rollup = data.repository && data.repository.object && data.repository.object.statusCheckRollup;
         if (!rollup) {
-            break;
+            // A commit that has no checks at all has a null rollup. Once pages have already been read,
+            // a missing one instead means an incomplete set, and callers must not mistake the checks we
+            // did manage to read for all of them.
+            if (contexts.length) {
+                throw new Error(`Incomplete status check rollup for ${oid}`);
+            }
+            return [];
         }
 
         contexts = contexts.concat(rollup.contexts.nodes);

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -318,7 +318,7 @@ query($owner:String!, $repo:String!, $oid:GitObjectID!, $cursor:String) {
         // A commit that has no checks at all has a null rollup
         const rollup = data.repository && data.repository.object && data.repository.object.statusCheckRollup;
         if (!rollup) {
-            return [];
+            break;
         }
 
         contexts = contexts.concat(rollup.contexts.nodes);

--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -265,6 +265,69 @@ query {
         });
 }
 
+/**
+ * Get every check run and commit status that feeds the status indicator GitHub shows for a single commit.
+ * These are two separate concepts in the GitHub API, and the "status check rollup" is what combines them.
+ *
+ * @param {String} owner
+ * @param {String} repo
+ * @param {String} oid The full 40 character commit SHA
+ * @returns {Promise<Array<Object>>}
+ */
+async function getStatusCheckRollup(owner, repo, oid) {
+    const graphQLQuery = `
+query($owner:String!, $repo:String!, $oid:GitObjectID!, $cursor:String) {
+    repository(owner: $owner, name: $repo) {
+        object(oid: $oid) {
+            ... on Commit {
+                statusCheckRollup {
+                    contexts(first: 100, after: $cursor) {
+                        pageInfo {
+                            endCursor
+                            hasNextPage
+                        }
+                        nodes {
+                            type: __typename
+                            ... on CheckRun {
+                                name
+                                status
+                                conclusion
+                            }
+                            ... on StatusContext {
+                                context
+                                state
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+    `;
+
+    let contexts = [];
+    let cursor = null;
+
+    do {
+        // eslint-disable-next-line no-await-in-loop
+        const data = await getOctokit().graphql(graphQLQuery, {
+            owner, repo, oid, cursor,
+        });
+
+        // A commit that has no checks at all has a null rollup
+        const rollup = data.repository && data.repository.object && data.repository.object.statusCheckRollup;
+        if (!rollup) {
+            return [];
+        }
+
+        contexts = contexts.concat(rollup.contexts.nodes);
+        cursor = rollup.contexts.pageInfo.hasNextPage ? rollup.contexts.pageInfo.endCursor : null;
+    } while (cursor);
+
+    return contexts;
+}
+
 function getCheckRuns(repo, headSHA) {
     return getOctokit().rest.checks.listForRef({
         owner: getRequestParams().owner,
@@ -559,4 +622,5 @@ export {
     updateComment,
     getWorkflowRuns,
     getWorkflowRun,
+    getStatusCheckRollup,
 };

--- a/src/js/lib/commitCheckStatuses.js
+++ b/src/js/lib/commitCheckStatuses.js
@@ -25,8 +25,9 @@ const FAILED_CHECK_RUN_CONCLUSIONS = ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTI
 const FAILED_STATUS_CONTEXT_STATES = ['ERROR', 'FAILURE'];
 const UNFINISHED_STATUS_CONTEXT_STATES = ['PENDING', 'EXPECTED'];
 
-// A commit high up in a PR's history never changes, but the head commit's checks do, so verdicts
-// are only trusted for as long as it takes a check to plausibly finish and report a new result.
+// How long a commit stays green on one lookup. A commit high up in a PR's history never changes, but
+// the head commit's checks do, so a commit we have greened is re-checked once GitHub puts the red X
+// back and this much time has passed.
 const VERDICT_LIFETIME_MS = 60000;
 
 // Keyed by commit SHA, so that scrolling through a PR doesn't re-request the same commit's checks.
@@ -64,7 +65,14 @@ function isUnfinished(context) {
  * @returns {Boolean}
  */
 function onlyIgnoredChecksAreFailing(contexts) {
-    const contextsThatCount = _.reject(contexts, context => _.contains(CONST.IGNORED_CHECK_RUN_NAMES, getContextName(context)));
+    const [ignoredContexts, contextsThatCount] = _.partition(contexts, context => _.contains(CONST.IGNORED_CHECK_RUN_NAMES, getContextName(context)));
+
+    // An ignored check has to be the thing making GitHub show the commit as failed. Requiring that is also
+    // what keeps a response we couldn't read from turning a genuinely failing commit green.
+    if (!_.any(ignoredContexts, isFailing)) {
+        return false;
+    }
+
     return !_.any(contextsThatCount, context => isFailing(context) || isUnfinished(context));
 }
 
@@ -84,23 +92,30 @@ function scheduleScan() {
 }
 
 /**
- * The verdict for a commit, requesting it in the background when we don't have a fresh one yet.
- * Returns undefined while a commit has never been looked up.
+ * Whether a commit should be shown as passing right now, requesting a verdict in the background
+ * when we don't have a fresh one. Answers false until a verdict arrives, so a commit is only ever
+ * greened on a result we currently trust.
  *
  * @param {String} owner
  * @param {String} repo
  * @param {String} sha
- * @returns {Boolean|undefined}
+ * @returns {Boolean}
  */
-function getVerdict(owner, repo, sha) {
+function shouldShowAsPassing(owner, repo, sha) {
     const verdict = verdicts[sha];
-    const isStale = !verdict || (Date.now() - verdict.fetchedAt) > VERDICT_LIFETIME_MS;
 
-    if (isStale && !requestsInFlight[sha]) {
+    // A verdict of false leaves GitHub's own indicator in place, and that indicator is always live, so
+    // only a verdict we act on can go stale in a way that misleads. That keeps a PR full of genuinely
+    // failing commits from re-requesting every one of them for as long as the tab stays open.
+    if (verdict && (!verdict.shouldShowAsPassing || (Date.now() - verdict.fetchedAt) <= VERDICT_LIFETIME_MS)) {
+        return verdict.shouldShowAsPassing;
+    }
+
+    if (!requestsInFlight[sha]) {
         requestsInFlight[sha] = true;
         API.getStatusCheckRollup(owner, repo, sha)
             .then((contexts) => {
-                verdicts[sha] = {onlyIgnoredChecksFailed: onlyIgnoredChecksAreFailing(contexts), fetchedAt: Date.now()};
+                verdicts[sha] = {shouldShowAsPassing: onlyIgnoredChecksAreFailing(contexts), fetchedAt: Date.now()};
 
                 // The page is usually done changing by the time a verdict lands, so nothing else would scan again.
                 scheduleScan();
@@ -113,8 +128,7 @@ function getVerdict(owner, repo, sha) {
             });
     }
 
-    // A stale verdict is still shown while its replacement is on the way, so the indicator doesn't flicker.
-    return verdict && verdict.onlyIgnoredChecksFailed;
+    return false;
 }
 
 /**
@@ -145,7 +159,7 @@ function scan() {
             return;
         }
 
-        if (!getVerdict(matches[1], matches[2], matches[3])) {
+        if (!shouldShowAsPassing(matches[1], matches[2], matches[3])) {
             return;
         }
 
@@ -155,13 +169,13 @@ function scan() {
     });
 
     _.each(document.querySelectorAll(TIMELINE_FAILING_INDICATOR_SELECTOR), (indicator) => {
-        const detailsUrl = indicator.parentElement.getAttribute('data-deferred-details-content-url') || '';
+        const detailsUrl = indicator.closest('details.commit-build-statuses').getAttribute('data-deferred-details-content-url') || '';
         const matches = detailsUrl.match(TIMELINE_STATUS_URL_REGEX);
         if (!matches) {
             return;
         }
 
-        if (!getVerdict(matches[1], matches[2], matches[3])) {
+        if (!shouldShowAsPassing(matches[1], matches[2], matches[3])) {
             return;
         }
 

--- a/src/js/lib/commitCheckStatuses.js
+++ b/src/js/lib/commitCheckStatuses.js
@@ -1,0 +1,215 @@
+import _ from 'underscore';
+import ReactNativeOnyx from 'react-native-onyx';
+import * as API from './api';
+import * as Preferences from './actions/Preferences';
+import ONYXKEYS from '../ONYXKEYS';
+import CONST from '../CONST';
+
+// GitHub renders the per-commit status indicator with two different components, so both have
+// to be rewritten to cover a whole PR: the React commit rows on the "Commits" tab, and the
+// server-rendered rows in the conversation timeline.
+const REACT_COMMIT_ROW_SELECTOR = '[data-testid="commit-row-item"]';
+const REACT_FAILING_BADGE_SELECTOR = '[data-testid="checks-status-badge-button"][aria-label="Status checks: failure"]';
+const TIMELINE_FAILING_INDICATOR_SELECTOR = 'details.commit-build-statuses summary.color-fg-danger';
+
+// The commit SHA has to come out of the markup rather than the URL because a PR page shows many commits at once.
+const REACT_COMMIT_LINK_REGEX = /^\/([^/]+)\/([^/]+)\/pull\/\d+\/commits\/([0-9a-f]{40})$/;
+const TIMELINE_STATUS_URL_REGEX = /^\/([^/]+)\/([^/]+)\/commit\/([0-9a-f]{40})\/status-details/;
+
+// The `d` attribute of GitHub's octicon-check, which replaces the octicon-x we are hiding.
+const CHECK_ICON_PATH = 'M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z';
+
+// Conclusions that make GitHub show a commit as failed. A check run that has any other conclusion
+// (success, skipped, neutral) is not something that keeps a commit from being green.
+const FAILED_CHECK_RUN_CONCLUSIONS = ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE'];
+const FAILED_STATUS_CONTEXT_STATES = ['ERROR', 'FAILURE'];
+const UNFINISHED_STATUS_CONTEXT_STATES = ['PENDING', 'EXPECTED'];
+
+// A commit high up in a PR's history never changes, but the head commit's checks do, so verdicts
+// are only trusted for as long as it takes a check to plausibly finish and report a new result.
+const VERDICT_LIFETIME_MS = 60000;
+
+// Keyed by commit SHA, so that scrolling through a PR doesn't re-request the same commit's checks.
+const verdicts = {};
+const requestsInFlight = {};
+
+let observer = null;
+let scanScheduled = false;
+let preferenceSubscribed = false;
+
+function getContextName(context) {
+    return context.type === 'CheckRun' ? context.name : context.context;
+}
+
+function isFailing(context) {
+    if (context.type === 'CheckRun') {
+        return _.contains(FAILED_CHECK_RUN_CONCLUSIONS, context.conclusion);
+    }
+    return _.contains(FAILED_STATUS_CONTEXT_STATES, context.state);
+}
+
+function isUnfinished(context) {
+    if (context.type === 'CheckRun') {
+        return context.status !== 'COMPLETED';
+    }
+    return _.contains(UNFINISHED_STATUS_CONTEXT_STATES, context.state);
+}
+
+/**
+ * Whether a commit that GitHub shows as failing only fails because of checks we ignore.
+ * Checks that are still running count against it, because until they finish we can't tell
+ * whether the ignored check really is the only failure.
+ *
+ * @param {Array<Object>} contexts
+ * @returns {Boolean}
+ */
+function onlyIgnoredChecksAreFailing(contexts) {
+    const contextsThatCount = _.reject(contexts, context => _.contains(CONST.IGNORED_CHECK_RUN_NAMES, getContextName(context)));
+    return !_.any(contextsThatCount, context => isFailing(context) || isUnfinished(context));
+}
+
+// Coalesce bursts of mutations into a single scan per animation frame so that the rapid
+// stream of DOM changes during page load doesn't trigger a scan per node.
+function scheduleScan() {
+    if (scanScheduled) {
+        return;
+    }
+    scanScheduled = true;
+    requestAnimationFrame(() => {
+        scanScheduled = false;
+
+        // eslint-disable-next-line no-use-before-define
+        scan();
+    });
+}
+
+/**
+ * The verdict for a commit, requesting it in the background when we don't have a fresh one yet.
+ * Returns undefined while a commit has never been looked up.
+ *
+ * @param {String} owner
+ * @param {String} repo
+ * @param {String} sha
+ * @returns {Boolean|undefined}
+ */
+function getVerdict(owner, repo, sha) {
+    const verdict = verdicts[sha];
+    const isStale = !verdict || (Date.now() - verdict.fetchedAt) > VERDICT_LIFETIME_MS;
+
+    if (isStale && !requestsInFlight[sha]) {
+        requestsInFlight[sha] = true;
+        API.getStatusCheckRollup(owner, repo, sha)
+            .then((contexts) => {
+                verdicts[sha] = {onlyIgnoredChecksFailed: onlyIgnoredChecksAreFailing(contexts), fetchedAt: Date.now()};
+
+                // The page is usually done changing by the time a verdict lands, so nothing else would scan again.
+                scheduleScan();
+            })
+            .catch((error) => {
+                console.error('Error fetching check statuses for commit', sha, error);
+            })
+            .finally(() => {
+                delete requestsInFlight[sha];
+            });
+    }
+
+    // A stale verdict is still shown while its replacement is on the way, so the indicator doesn't flicker.
+    return verdict && verdict.onlyIgnoredChecksFailed;
+}
+
+/**
+ * Turns a red X octicon into a green check octicon.
+ *
+ * @param {Element} indicator The element holding the octicon
+ */
+function replaceFailureIcon(indicator) {
+    const icon = indicator.querySelector('svg.octicon-x');
+    if (!icon) {
+        return;
+    }
+
+    icon.classList.remove('octicon-x');
+    icon.classList.add('octicon-check');
+
+    const path = icon.querySelector('path');
+    if (path) {
+        path.setAttribute('d', CHECK_ICON_PATH);
+    }
+}
+
+function scan() {
+    _.each(document.querySelectorAll(REACT_COMMIT_ROW_SELECTOR), (row) => {
+        const badge = row.querySelector(REACT_FAILING_BADGE_SELECTOR);
+        const matches = (row.getAttribute('data-commit-link') || '').match(REACT_COMMIT_LINK_REGEX);
+        if (!badge || !matches) {
+            return;
+        }
+
+        if (!getVerdict(matches[1], matches[2], matches[3])) {
+            return;
+        }
+
+        badge.setAttribute('aria-label', 'Status checks: success');
+        badge.style.setProperty('--checks-icon-color', 'var(--bgColor-success-emphasis, var(--color-success-emphasis))');
+        replaceFailureIcon(badge);
+    });
+
+    _.each(document.querySelectorAll(TIMELINE_FAILING_INDICATOR_SELECTOR), (indicator) => {
+        const detailsUrl = indicator.parentElement.getAttribute('data-deferred-details-content-url') || '';
+        const matches = detailsUrl.match(TIMELINE_STATUS_URL_REGEX);
+        if (!matches) {
+            return;
+        }
+
+        if (!getVerdict(matches[1], matches[2], matches[3])) {
+            return;
+        }
+
+        indicator.classList.remove('color-fg-danger');
+        indicator.classList.add('color-fg-success');
+        replaceFailureIcon(indicator);
+    });
+}
+
+function start() {
+    if (observer) {
+        return;
+    }
+
+    scheduleScan();
+
+    // GitHub re-renders these indicators as checks report in, which puts the red X back.
+    observer = new MutationObserver(scheduleScan);
+    observer.observe(document.body, {childList: true, subtree: true});
+}
+
+/**
+ * Shows a commit as passing when the only check holding it back is one we ignore, so that a PR's
+ * commit history still says which commits had their tests passing.
+ */
+function initCommitCheckStatuses() {
+    if (preferenceSubscribed) {
+        return;
+    }
+    preferenceSubscribed = true;
+
+    // Every lookup needs the API, and an unauthenticated Octokit gets cached for the life of the page,
+    // so nothing can start until the token the user entered on the dashboard has loaded out of Onyx.
+    if (Preferences.getGitHubToken()) {
+        start();
+        return;
+    }
+
+    ReactNativeOnyx.connect({
+        key: ONYXKEYS.PREFERENCES,
+        callback: () => {
+            if (!Preferences.getGitHubToken()) {
+                return;
+            }
+            start();
+        },
+    });
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export {initCommitCheckStatuses};

--- a/src/js/lib/commitCheckStatuses.js
+++ b/src/js/lib/commitCheckStatuses.js
@@ -5,32 +5,52 @@ import * as Preferences from './actions/Preferences';
 import ONYXKEYS from '../ONYXKEYS';
 import CONST from '../CONST';
 
-// GitHub renders the per-commit status indicator with two different components, so both have
-// to be rewritten to cover a whole PR: the React commit rows on the "Commits" tab, and the
-// server-rendered rows in the conversation timeline.
+// Marks an indicator we have rewritten, so it can be found again and put back if the commit turns out to
+// be failing after all. Without it a rewritten indicator no longer matches anything we look for.
+const REWRITTEN_ATTRIBUTE = 'data-k2-ignoring-peer-review';
+
+// GitHub renders the per-commit status indicator with two different components, so both have to be
+// rewritten to cover a whole PR: the React commit rows on the "Commits" tab, and the server-rendered rows
+// in the conversation timeline.
 const REACT_COMMIT_ROW_SELECTOR = '[data-testid="commit-row-item"]';
-const REACT_FAILING_BADGE_SELECTOR = '[data-testid="checks-status-badge-button"][aria-label="Status checks: failure"]';
-const TIMELINE_FAILING_INDICATOR_SELECTOR = 'details.commit-build-statuses summary.color-fg-danger';
+const REACT_BADGE_SELECTOR = `[data-testid="checks-status-badge-button"][aria-label="Status checks: failure"], [data-testid="checks-status-badge-button"][${REWRITTEN_ATTRIBUTE}]`;
+const TIMELINE_INDICATOR_SELECTOR = `details.commit-build-statuses summary.color-fg-danger, details.commit-build-statuses summary[${REWRITTEN_ATTRIBUTE}]`;
+const TIMELINE_DETAILS_SELECTOR = 'details.commit-build-statuses';
 
 // The commit SHA has to come out of the markup rather than the URL because a PR page shows many commits at once.
 const REACT_COMMIT_LINK_REGEX = /^\/([^/]+)\/([^/]+)\/pull\/\d+\/commits\/([0-9a-f]{40})$/;
 const TIMELINE_STATUS_URL_REGEX = /^\/([^/]+)\/([^/]+)\/commit\/([0-9a-f]{40})\/status-details/;
 
-// The `d` attribute of GitHub's octicon-check, which replaces the octicon-x we are hiding.
+const FAILING_LABEL = 'Status checks: failure';
+const PASSING_LABEL = 'Status checks: success, ignoring the peer review check';
+const FAILING_ICON_COLOR = 'var(--bgColor-danger-emphasis, var(--color-scale-red-4))';
+const PASSING_ICON_COLOR = 'var(--bgColor-success-emphasis, var(--color-success-emphasis))';
+
+// The `d` attributes of GitHub's octicon-check and octicon-x, which we swap between.
 const CHECK_ICON_PATH = 'M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z';
+// eslint-disable-next-line max-len
+const X_ICON_PATH = 'M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z';
 
-// Conclusions that make GitHub show a commit as failed. A check run that has any other conclusion
-// (success, skipped, neutral) is not something that keeps a commit from being green.
-const FAILED_CHECK_RUN_CONCLUSIONS = ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE'];
-const FAILED_STATUS_CONTEXT_STATES = ['ERROR', 'FAILURE'];
-const UNFINISHED_STATUS_CONTEXT_STATES = ['PENDING', 'EXPECTED'];
+// Turning a red X green is the one thing here that can mislead, so a check only counts as out of the way
+// when it says so. Anything else — a conclusion we don't recognise, a check still running, a context type
+// GitHub adds later — keeps the commit red.
+const PASSING_CHECK_RUN_CONCLUSIONS = ['SUCCESS', 'NEUTRAL', 'SKIPPED'];
 
-// How long a commit stays green on one lookup. A commit high up in a PR's history never changes, but
-// the head commit's checks do, so a commit we have greened is re-checked once GitHub puts the red X
-// back and this much time has passed.
+// Conversely, a check has to have definitely failed before we treat it as the reason GitHub shows a commit
+// as failed, so this list is deliberately not the inverse of the one above.
+const FAILED_CHECK_RUN_CONCLUSIONS = ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE'];
+
+const UNREPORTED_STATUS_CONTEXT_STATES = ['PENDING', 'EXPECTED'];
+
+// How long a verdict lasts when the commit's checks could still report something new.
 const VERDICT_LIFETIME_MS = 60000;
 
-// Keyed by commit SHA, so that scrolling through a PR doesn't re-request the same commit's checks.
+// Opening the commit list of a busy PR asks about every failing commit at once, so lookups are spread
+// across several scans rather than opening a connection per commit.
+const MAX_CONCURRENT_REQUESTS = 8;
+
+// Keyed by owner/repo/SHA, because check runs belong to a repository as well as a commit and the same SHA
+// shows up in more than one of them, most obviously a fork and the repository it was forked from.
 const verdicts = {};
 const requestsInFlight = {};
 
@@ -38,42 +58,63 @@ let observer = null;
 let scanScheduled = false;
 let preferenceSubscribed = false;
 
-function getContextName(context) {
-    return context.type === 'CheckRun' ? context.name : context.context;
+function getWorkflowPath(context) {
+    const checkSuite = context.checkSuite || {};
+    const workflowRun = checkSuite.workflowRun || {};
+    return (workflowRun.workflow && workflowRun.workflow.resourcePath) || '';
 }
 
-function isFailing(context) {
-    if (context.type === 'CheckRun') {
-        return _.contains(FAILED_CHECK_RUN_CONCLUSIONS, context.conclusion);
-    }
-    return _.contains(FAILED_STATUS_CONTEXT_STATES, context.state);
+/**
+ * Whether a check is one we deliberately don't hold against a commit. Matching on name alone would let a
+ * PR author hide a real failure by naming one of their own jobs after the peer review check, so the run
+ * it came from has to be the ruleset-required one as well.
+ *
+ * @param {Object} context
+ * @returns {Boolean}
+ */
+function isIgnoredCheck(context) {
+    return context.type === 'CheckRun'
+        && _.contains(CONST.IGNORED_CHECK_RUN_NAMES, context.name)
+        && getWorkflowPath(context).indexOf(CONST.PEER_REVIEW_WORKFLOW_PATH) > -1;
 }
 
-function isUnfinished(context) {
+function isPassing(context) {
     if (context.type === 'CheckRun') {
-        return context.status !== 'COMPLETED';
+        return context.status === 'COMPLETED' && _.contains(PASSING_CHECK_RUN_CONCLUSIONS, context.conclusion);
     }
-    return _.contains(UNFINISHED_STATUS_CONTEXT_STATES, context.state);
+    return context.type === 'StatusContext' && context.state === 'SUCCESS';
+}
+
+function hasFailed(context) {
+    if (context.type === 'CheckRun') {
+        return context.status === 'COMPLETED' && _.contains(FAILED_CHECK_RUN_CONCLUSIONS, context.conclusion);
+    }
+    return context.type === 'StatusContext' && (context.state === 'FAILURE' || context.state === 'ERROR');
+}
+
+function hasReported(context) {
+    if (context.type === 'CheckRun') {
+        return context.status === 'COMPLETED';
+    }
+    return context.type === 'StatusContext' && !_.contains(UNREPORTED_STATUS_CONTEXT_STATES, context.state);
 }
 
 /**
  * Whether a commit that GitHub shows as failing only fails because of checks we ignore.
- * Checks that are still running count against it, because until they finish we can't tell
- * whether the ignored check really is the only failure.
  *
  * @param {Array<Object>} contexts
  * @returns {Boolean}
  */
 function onlyIgnoredChecksAreFailing(contexts) {
-    const [ignoredContexts, contextsThatCount] = _.partition(contexts, context => _.contains(CONST.IGNORED_CHECK_RUN_NAMES, getContextName(context)));
+    const [ignoredContexts, contextsThatCount] = _.partition(contexts, isIgnoredCheck);
 
     // An ignored check has to be the thing making GitHub show the commit as failed. Requiring that is also
     // what keeps a response we couldn't read from turning a genuinely failing commit green.
-    if (!_.any(ignoredContexts, isFailing)) {
+    if (!_.any(ignoredContexts, hasFailed)) {
         return false;
     }
 
-    return !_.any(contextsThatCount, context => isFailing(context) || isUnfinished(context));
+    return _.all(contextsThatCount, isPassing);
 }
 
 // Coalesce bursts of mutations into a single scan per animation frame so that the rapid
@@ -92,96 +133,144 @@ function scheduleScan() {
 }
 
 /**
- * Whether a commit should be shown as passing right now, requesting a verdict in the background
- * when we don't have a fresh one. Answers false until a verdict arrives, so a commit is only ever
- * greened on a result we currently trust.
+ * Whether a commit should be shown as passing, or null while there is no verdict worth acting on. Requests
+ * one in the background when the one we have has expired.
  *
  * @param {String} owner
  * @param {String} repo
  * @param {String} sha
- * @returns {Boolean}
+ * @returns {Boolean|null}
  */
-function shouldShowAsPassing(owner, repo, sha) {
-    const verdict = verdicts[sha];
+function getVerdict(owner, repo, sha) {
+    const key = `${owner}/${repo}/${sha}`;
+    const verdict = verdicts[key];
 
-    // A verdict of false leaves GitHub's own indicator in place, and that indicator is always live, so
-    // only a verdict we act on can go stale in a way that misleads. That keeps a PR full of genuinely
-    // failing commits from re-requesting every one of them for as long as the tab stays open.
-    if (verdict && (!verdict.shouldShowAsPassing || (Date.now() - verdict.fetchedAt) <= VERDICT_LIFETIME_MS)) {
+    if (verdict && (verdict.isFinal || (Date.now() - verdict.fetchedAt) <= VERDICT_LIFETIME_MS)) {
         return verdict.shouldShowAsPassing;
     }
 
-    if (!requestsInFlight[sha]) {
-        requestsInFlight[sha] = true;
+    if (!requestsInFlight[key] && _.size(requestsInFlight) < MAX_CONCURRENT_REQUESTS) {
+        requestsInFlight[key] = true;
         API.getStatusCheckRollup(owner, repo, sha)
             .then((contexts) => {
-                verdicts[sha] = {shouldShowAsPassing: onlyIgnoredChecksAreFailing(contexts), fetchedAt: Date.now()};
+                const shouldShowAsPassing = onlyIgnoredChecksAreFailing(contexts);
+                verdicts[key] = {
+                    shouldShowAsPassing,
 
-                // The page is usually done changing by the time a verdict lands, so nothing else would scan again.
-                scheduleScan();
+                    // A commit that is failing with every check reported can't change without something
+                    // being re-run, so that verdict is worth keeping and a PR full of failing commits
+                    // stops asking about them. Everything else expires, including a commit still waiting
+                    // on checks, which is the usual state of one being worked on.
+                    isFinal: !shouldShowAsPassing && contexts.length > 0 && _.all(contexts, hasReported),
+                    fetchedAt: Date.now(),
+                };
             })
             .catch((error) => {
                 console.error('Error fetching check statuses for commit', sha, error);
+
+                // Recording the failure is what stops a bad token or a rate limit from turning every scan
+                // into another request. A null verdict leaves the indicator as GitHub rendered it.
+                verdicts[key] = {shouldShowAsPassing: null, isFinal: false, fetchedAt: Date.now()};
             })
             .finally(() => {
-                delete requestsInFlight[sha];
+                delete requestsInFlight[key];
+
+                // The page is usually done changing by the time a verdict lands, so nothing else would
+                // scan again. This also picks up commits that couldn't get a request slot earlier.
+                scheduleScan();
             });
     }
 
-    return false;
+    return null;
 }
 
-/**
- * Turns a red X octicon into a green check octicon.
- *
- * @param {Element} indicator The element holding the octicon
- */
-function replaceFailureIcon(indicator) {
-    const icon = indicator.querySelector('svg.octicon-x');
+function replaceIcon(element, currentClass, newClass, iconPath) {
+    const icon = element.querySelector(`svg.${currentClass}`);
     if (!icon) {
         return;
     }
 
-    icon.classList.remove('octicon-x');
-    icon.classList.add('octicon-check');
+    icon.classList.remove(currentClass);
+    icon.classList.add(newClass);
 
     const path = icon.querySelector('path');
     if (path) {
-        path.setAttribute('d', CHECK_ICON_PATH);
+        path.setAttribute('d', iconPath);
     }
 }
 
-function scan() {
+function showAsPassing(indicator) {
+    indicator.element.setAttribute(REWRITTEN_ATTRIBUTE, '');
+
+    if (indicator.isReactBadge) {
+        indicator.element.setAttribute('aria-label', PASSING_LABEL);
+        indicator.element.style.setProperty('--checks-icon-color', PASSING_ICON_COLOR);
+    } else {
+        indicator.element.classList.remove('color-fg-danger');
+        indicator.element.classList.add('color-fg-success');
+    }
+
+    replaceIcon(indicator.element, 'octicon-x', 'octicon-check', CHECK_ICON_PATH);
+}
+
+function showAsFailing(indicator) {
+    indicator.element.removeAttribute(REWRITTEN_ATTRIBUTE);
+
+    if (indicator.isReactBadge) {
+        indicator.element.setAttribute('aria-label', FAILING_LABEL);
+        indicator.element.style.setProperty('--checks-icon-color', FAILING_ICON_COLOR);
+    } else {
+        indicator.element.classList.remove('color-fg-success');
+        indicator.element.classList.add('color-fg-danger');
+    }
+
+    replaceIcon(indicator.element, 'octicon-check', 'octicon-x', X_ICON_PATH);
+}
+
+/**
+ * Every status indicator on the page that either shows a failure or is one we have already rewritten,
+ * paired with the commit it belongs to.
+ *
+ * @returns {Array<Object>}
+ */
+function findIndicators() {
+    const indicators = [];
+
     _.each(document.querySelectorAll(REACT_COMMIT_ROW_SELECTOR), (row) => {
-        const badge = row.querySelector(REACT_FAILING_BADGE_SELECTOR);
+        const badge = row.querySelector(REACT_BADGE_SELECTOR);
         const matches = (row.getAttribute('data-commit-link') || '').match(REACT_COMMIT_LINK_REGEX);
-        if (!badge || !matches) {
-            return;
+        if (badge && matches) {
+            indicators.push({
+                element: badge, isReactBadge: true, owner: matches[1], repo: matches[2], sha: matches[3],
+            });
         }
-
-        if (!shouldShowAsPassing(matches[1], matches[2], matches[3])) {
-            return;
-        }
-
-        badge.setAttribute('aria-label', 'Status checks: success');
-        badge.style.setProperty('--checks-icon-color', 'var(--bgColor-success-emphasis, var(--color-success-emphasis))');
-        replaceFailureIcon(badge);
     });
 
-    _.each(document.querySelectorAll(TIMELINE_FAILING_INDICATOR_SELECTOR), (indicator) => {
-        const detailsUrl = indicator.closest('details.commit-build-statuses').getAttribute('data-deferred-details-content-url') || '';
+    _.each(document.querySelectorAll(TIMELINE_INDICATOR_SELECTOR), (summary) => {
+        const details = summary.closest(TIMELINE_DETAILS_SELECTOR);
+        const detailsUrl = (details && details.getAttribute('data-deferred-details-content-url')) || '';
         const matches = detailsUrl.match(TIMELINE_STATUS_URL_REGEX);
-        if (!matches) {
-            return;
+        if (matches) {
+            indicators.push({
+                element: summary, isReactBadge: false, owner: matches[1], repo: matches[2], sha: matches[3],
+            });
         }
+    });
 
-        if (!shouldShowAsPassing(matches[1], matches[2], matches[3])) {
-            return;
+    return indicators;
+}
+
+function scan() {
+    _.each(findIndicators(), (indicator) => {
+        const isRewritten = indicator.element.hasAttribute(REWRITTEN_ATTRIBUTE);
+        const verdict = getVerdict(indicator.owner, indicator.repo, indicator.sha);
+
+        // A null verdict means we have nothing to say yet, so whatever is on screen stays.
+        if (verdict === true && !isRewritten) {
+            showAsPassing(indicator);
+        } else if (verdict === false && isRewritten) {
+            showAsFailing(indicator);
         }
-
-        indicator.classList.remove('color-fg-danger');
-        indicator.classList.add('color-fg-success');
-        replaceFailureIcon(indicator);
     });
 }
 

--- a/src/js/lib/pages/github/pr.js
+++ b/src/js/lib/pages/github/pr.js
@@ -3,6 +3,7 @@ import Base from './_base';
 import ToggleTimestamps from '../../../module/ToggleTimestamps/ToggleTimestamps';
 import ToggleAutoLoadMore from '../../../module/ToggleAutoLoadMore/ToggleAutoLoadMore';
 import * as autoLoadMoreComments from '../../autoLoadMoreComments';
+import * as commitCheckStatuses from '../../commitCheckStatuses';
 
 /**
  * Replaces all `- [ ]` with `- [x]` in textareas with specific names
@@ -144,6 +145,7 @@ export default function () {
         setInterval(() => PrPage.renderTranslationWorkflowButtons(), 2000);
 
         autoLoadMoreComments.initAutoLoadMoreComments();
+        commitCheckStatuses.initCommitCheckStatuses();
     };
 
     return PrPage;


### PR DESCRIPTION
### Fixed Issues
$ https://github.com/Expensify/Expensify/issues/668743

This is the second half of that issue. [#367](https://github.com/Expensify/k2-extension/pull/367) covered the K2 dashboard's `Github Actions:` status; this covers the per-commit indicators on a PR.

### Problem

Every commit in a PR's history shows a red X or a green check next to its SHA, which tells you whether tests passed for that commit. Since the org-wide ruleset started triggering [verifyPeerReview.yml](https://github.com/Expensify/GitHub-Actions/blob/main/.github/workflows/verifyPeerReview.yml), its `Check independent approval` job fails until the PR has been peer-reviewed, so every commit shows a red X regardless of whether its tests passed.

That makes the commit list useless for its main purpose. To find which commits had tests passing — while iterating on a draft PR, say — you have to open the check run for each commit individually and read down the list to see whether peer review was the only thing missing.

### Solution

Rewrite the indicator to a green check when the only thing failing on that commit is a check we ignore.

- `src/js/CONST.js` (new) — hoists `IGNORED_CHECK_RUN_NAMES` out of `actions/PullRequests.js`, which now has a second consumer.
- `src/js/lib/api.js` — new `getStatusCheckRollup()`. It queries GraphQL's `statusCheckRollup`, which is what GitHub's own indicator is built from, so it covers check runs *and* commit statuses in one paginated call. The existing REST `getCheckRuns` only covers check runs.
- `src/js/lib/commitCheckStatuses.js` (new) — a `MutationObserver`-driven scan, in the same shape as `autoLoadMoreComments`, that finds failing indicators and swaps the octicon. It handles both markups GitHub uses: the React rows on the Commits tab (`checks-status-badge-button`) and the server-rendered rows in the conversation timeline (`details.commit-build-statuses`). Each row's SHA comes from its own attribute, never the page URL, so rows resolve independently.
- `src/js/lib/pages/github/pr.js` — calls `initCommitCheckStatuses()`.

Turning a red X green is the one thing here that can mislead a reviewer, so everything below is built around not doing it by accident:

1. **A commit stays red if any non-ignored check is still running.** Until those finish you can't know peer review is the only failure, and flashing green mid-run is the exact false signal this is meant to remove.
2. **Passing is an allow-list.** Only `SUCCESS`/`NEUTRAL`/`SKIPPED` check runs and `SUCCESS` status contexts count as out of the way. A conclusion we don't recognise, or a context type GitHub adds to the union later, keeps the commit red rather than being read as passing.
3. **Greening requires a failing ignored check.** So an empty or unreadable response leaves a genuinely failing commit red. Relatedly, `getStatusCheckRollup` throws rather than returning a partial set when a later page of the rollup comes back empty.
4. **The ignored check has to come from the ruleset-required workflow run.** Matching on the name alone would let a PR author hide a real failure by naming one of their own jobs `Check independent approval`. A required workflow run keeps its source repo in the run's resource path (`.../required/Expensify/GitHub-Actions/.github/workflows/verifyPeerReview.yml`), which an author can't reproduce from a workflow file on their own branch. Confirmed identical in App, Auth and Web-Expensify.
5. **A rewritten indicator gets put back if a later verdict says the commit is failing.** The timeline's server-rendered rows never re-render on their own, so without this a green could outlive the result it was based on.
6. **Verdicts are keyed on owner/repo/SHA**, because check runs belong to a repository as well as a commit and the same SHA appears in both a fork and its base repo.

Verdicts expire after 60s. The exception is a commit that is failing with every check already reported — that can't change without something being re-run, so it's kept and a PR full of failing commits stops asking about them. Failed lookups are cached too, so a bad token or a rate limit can't turn every scan into another request, and concurrent lookups are capped at 8.

The `32 / 34` counts are left untouched, matching GitHub's own behaviour — it already shows counts like `12 / 28` next to a green check.

### Tests

Verified with Playwright driving the unpacked extension against live PRs. Note that this needs Playwright's bundled Chromium — Chrome 137 dropped `--load-extension`.

1. Run `npm run build`, then load the `dist/` folder as an unpacked extension.
2. Open https://github.com/Expensify/App/pull/97967/commits, whose history has commits failing only `Check independent approval`, commits failing real checks as well, and commits failing nothing.
3. Confirm `57c9915c` shows a green check — `Check independent approval` is its only failing check.
4. Confirm `2df08710` still shows a red X — it fails `checklist` as well as peer review.
5. Confirm `085d77ed`, `144fd040`, `25c0842b`, `298fd2ff` and `f71176a5` still show a red X — all fail real checks.
6. Confirm `24b79eb5` and `8e29096a` still show a green check — they were already passing and must not be disturbed.
7. Open https://github.com/Expensify/App/pull/97967 and repeat steps 3-6 against the commit rows in the conversation timeline.

I derived the expected state for all 9 commits from the check-runs API and asserted every indicator on both pages, so that's 18 assertions, all passing. `npm run lint` is clean.

I also captured GitHub's own failing markup with the extension unloaded and diffed it against the values the revert path restores — aria-label, icon colour, octicon class and path `d` for both markups all match exactly. The revert itself isn't exercised end-to-end, since that needs a commit whose checks change state mid-session.

Two things reviewers may want to weigh in on:

- There is no test harness in this repo, so `onlyIgnoredChecksAreFailing` — the function that makes the whole trust decision — is only covered through the browser. A table-driven test over the check-run/status-context matrix would be worth having, but adding a runner felt like its own PR.
- This has no preference toggle, matching how [#367](https://github.com/Expensify/k2-extension/pull/367) shipped the same suppression on the dashboard. Say so if you'd rather it were opt-in.

On the commits tab, `57c9915c` now reads `✓ 32 / 34` directly above `2df08710` at `✗ 33 / 37`, so the column can be scanned to see which commits actually had tests passing.
