### PR TITLE
Show the favicon as passing when peer review is the only failing check

### DIFF
--- a/src/js/lib/api.js
+++ b/src/js/lib/api.js
@@ -266,6 +266,30 @@ query {
 }
 
 /**
+ * Get the SHA of the commit at the head of a pull request, which is the commit whose checks GitHub's
+ * favicon and merge box report on.
+ *
+ * @param {String} owner
+ * @param {String} repo
+ * @param {Number} pullRequestNumber
+ * @returns {Promise<String|null>}
+ */
+function getPullRequestHeadRefOid(owner, repo, pullRequestNumber) {
+    const graphQLQuery = `
+query($owner:String!, $repo:String!, $number:Int!) {
+    repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+            headRefOid
+        }
+    }
+}
+    `;
+
+    return getOctokit().graphql(graphQLQuery, {owner, repo, number: pullRequestNumber})
+        .then(data => (data.repository && data.repository.pullRequest && data.repository.pullRequest.headRefOid) || null);
+}
+
+/**
  * Get every check run and commit status that feeds the status indicator GitHub shows for a single commit.
  * These are two separate concepts in the GitHub API, and the "status check rollup" is what combines them.
  *
@@ -635,4 +659,5 @@ export {
     getWorkflowRuns,
     getWorkflowRun,
     getStatusCheckRollup,
+    getPullRequestHeadRefOid,
 };

--- a/src/js/lib/checkStatusVerdicts.js
+++ b/src/js/lib/checkStatusVerdicts.js
@@ -1,0 +1,155 @@
+import _ from 'underscore';
+import * as API from './api';
+import CONST from '../CONST';
+
+// Turning a red X green is the one thing here that can mislead, so a check only counts as out of the way
+// when it says so. Anything else — a conclusion we don't recognise, a check still running, a context type
+// GitHub adds later — keeps the commit red.
+const PASSING_CHECK_RUN_CONCLUSIONS = ['SUCCESS', 'NEUTRAL', 'SKIPPED'];
+
+// Conversely, a check has to have definitely failed before we treat it as the reason GitHub shows a commit
+// as failed, so this list is deliberately not the inverse of the one above.
+const FAILED_CHECK_RUN_CONCLUSIONS = ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE'];
+
+const UNREPORTED_STATUS_CONTEXT_STATES = ['PENDING', 'EXPECTED'];
+
+// How long a verdict lasts when the commit's checks could still report something new.
+const VERDICT_LIFETIME_MS = 60000;
+
+// Opening the commit list of a busy PR asks about every failing commit at once, so lookups are spread
+// across several scans rather than opening a connection per commit.
+const MAX_CONCURRENT_REQUESTS = 8;
+
+// Keyed by owner/repo/SHA, because check runs belong to a repository as well as a commit and the same SHA
+// shows up in more than one of them, most obviously a fork and the repository it was forked from.
+const verdicts = {};
+const requestsInFlight = {};
+
+// A page has usually stopped changing by the time a verdict lands, so whatever is showing the status has
+// to be told rather than left to notice on its own.
+const settledListeners = [];
+
+function getWorkflowPath(context) {
+    const checkSuite = context.checkSuite || {};
+    const workflowRun = checkSuite.workflowRun || {};
+    return (workflowRun.workflow && workflowRun.workflow.resourcePath) || '';
+}
+
+/**
+ * Whether a check is one we deliberately don't hold against a commit. Matching on name alone would let a
+ * PR author hide a real failure by naming one of their own jobs after the peer review check, so the run
+ * it came from has to be the ruleset-required one as well.
+ *
+ * @param {Object} context
+ * @returns {Boolean}
+ */
+function isIgnoredCheck(context) {
+    return context.type === 'CheckRun'
+        && _.contains(CONST.IGNORED_CHECK_RUN_NAMES, context.name)
+        && getWorkflowPath(context).indexOf(CONST.PEER_REVIEW_WORKFLOW_PATH) > -1;
+}
+
+function isPassing(context) {
+    if (context.type === 'CheckRun') {
+        return context.status === 'COMPLETED' && _.contains(PASSING_CHECK_RUN_CONCLUSIONS, context.conclusion);
+    }
+    return context.type === 'StatusContext' && context.state === 'SUCCESS';
+}
+
+function hasFailed(context) {
+    if (context.type === 'CheckRun') {
+        return context.status === 'COMPLETED' && _.contains(FAILED_CHECK_RUN_CONCLUSIONS, context.conclusion);
+    }
+    return context.type === 'StatusContext' && (context.state === 'FAILURE' || context.state === 'ERROR');
+}
+
+function hasReported(context) {
+    if (context.type === 'CheckRun') {
+        return context.status === 'COMPLETED';
+    }
+    return context.type === 'StatusContext' && !_.contains(UNREPORTED_STATUS_CONTEXT_STATES, context.state);
+}
+
+/**
+ * Whether a commit that GitHub shows as failing only fails because of checks we ignore.
+ *
+ * @param {Array<Object>} contexts
+ * @returns {Boolean}
+ */
+function onlyIgnoredChecksAreFailing(contexts) {
+    const [ignoredContexts, contextsThatCount] = _.partition(contexts, isIgnoredCheck);
+
+    // An ignored check has to be the thing making GitHub show the commit as failed. Requiring that is also
+    // what keeps a response we couldn't read from turning a genuinely failing commit green.
+    if (!_.any(ignoredContexts, hasFailed)) {
+        return false;
+    }
+
+    return _.all(contextsThatCount, isPassing);
+}
+
+/**
+ * Whether a commit should be shown as passing, or null while there is no verdict worth acting on. Requests
+ * one in the background when the one we have has expired.
+ *
+ * @param {String} owner
+ * @param {String} repo
+ * @param {String} sha
+ * @returns {Boolean|null}
+ */
+function getVerdict(owner, repo, sha) {
+    const key = `${owner}/${repo}/${sha}`;
+    const verdict = verdicts[key];
+
+    if (verdict && (verdict.isFinal || (Date.now() - verdict.fetchedAt) <= VERDICT_LIFETIME_MS)) {
+        return verdict.shouldShowAsPassing;
+    }
+
+    if (!requestsInFlight[key] && _.size(requestsInFlight) < MAX_CONCURRENT_REQUESTS) {
+        requestsInFlight[key] = true;
+        API.getStatusCheckRollup(owner, repo, sha)
+            .then((contexts) => {
+                const shouldShowAsPassing = onlyIgnoredChecksAreFailing(contexts);
+                verdicts[key] = {
+                    shouldShowAsPassing,
+
+                    // A commit that is failing with every check reported can't change without something
+                    // being re-run, so that verdict is worth keeping and a PR full of failing commits
+                    // stops asking about them. Everything else expires, including a commit still waiting
+                    // on checks, which is the usual state of one being worked on.
+                    isFinal: !shouldShowAsPassing && contexts.length > 0 && _.all(contexts, hasReported),
+                    fetchedAt: Date.now(),
+                };
+            })
+            .catch((error) => {
+                console.error('Error fetching check statuses for commit', sha, error);
+
+                // Recording the failure is what stops a bad token or a rate limit from turning every scan
+                // into another request. A null verdict leaves the status as GitHub rendered it.
+                verdicts[key] = {shouldShowAsPassing: null, isFinal: false, fetchedAt: Date.now()};
+            })
+            .finally(() => {
+                delete requestsInFlight[key];
+
+                // This also releases a request slot, so anything that couldn't get one earlier can retry.
+                _.each(settledListeners, listener => listener());
+            });
+    }
+
+    return null;
+}
+
+/**
+ * Registers a callback to run whenever a lookup finishes, so a page that has already settled gets told
+ * about a verdict rather than waiting for its next change.
+ *
+ * @param {Function} listener
+ */
+function onVerdictSettled(listener) {
+    settledListeners.push(listener);
+}
+
+export {
+    getVerdict,
+    onVerdictSettled,
+};

--- a/src/js/lib/commitCheckStatuses.js
+++ b/src/js/lib/commitCheckStatuses.js
@@ -1,9 +1,8 @@
 import _ from 'underscore';
 import ReactNativeOnyx from 'react-native-onyx';
-import * as API from './api';
 import * as Preferences from './actions/Preferences';
+import * as CheckStatusVerdicts from './checkStatusVerdicts';
 import ONYXKEYS from '../ONYXKEYS';
-import CONST from '../CONST';
 
 // Marks an indicator we have rewritten, so it can be found again and put back if the commit turns out to
 // be failing after all. Without it a rewritten indicator no longer matches anything we look for.
@@ -31,158 +30,9 @@ const CHECK_ICON_PATH = 'M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1
 // eslint-disable-next-line max-len
 const X_ICON_PATH = 'M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z';
 
-// Turning a red X green is the one thing here that can mislead, so a check only counts as out of the way
-// when it says so. Anything else — a conclusion we don't recognise, a check still running, a context type
-// GitHub adds later — keeps the commit red.
-const PASSING_CHECK_RUN_CONCLUSIONS = ['SUCCESS', 'NEUTRAL', 'SKIPPED'];
-
-// Conversely, a check has to have definitely failed before we treat it as the reason GitHub shows a commit
-// as failed, so this list is deliberately not the inverse of the one above.
-const FAILED_CHECK_RUN_CONCLUSIONS = ['FAILURE', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE'];
-
-const UNREPORTED_STATUS_CONTEXT_STATES = ['PENDING', 'EXPECTED'];
-
-// How long a verdict lasts when the commit's checks could still report something new.
-const VERDICT_LIFETIME_MS = 60000;
-
-// Opening the commit list of a busy PR asks about every failing commit at once, so lookups are spread
-// across several scans rather than opening a connection per commit.
-const MAX_CONCURRENT_REQUESTS = 8;
-
-// Keyed by owner/repo/SHA, because check runs belong to a repository as well as a commit and the same SHA
-// shows up in more than one of them, most obviously a fork and the repository it was forked from.
-const verdicts = {};
-const requestsInFlight = {};
-
 let observer = null;
 let scanScheduled = false;
 let preferenceSubscribed = false;
-
-function getWorkflowPath(context) {
-    const checkSuite = context.checkSuite || {};
-    const workflowRun = checkSuite.workflowRun || {};
-    return (workflowRun.workflow && workflowRun.workflow.resourcePath) || '';
-}
-
-/**
- * Whether a check is one we deliberately don't hold against a commit. Matching on name alone would let a
- * PR author hide a real failure by naming one of their own jobs after the peer review check, so the run
- * it came from has to be the ruleset-required one as well.
- *
- * @param {Object} context
- * @returns {Boolean}
- */
-function isIgnoredCheck(context) {
-    return context.type === 'CheckRun'
-        && _.contains(CONST.IGNORED_CHECK_RUN_NAMES, context.name)
-        && getWorkflowPath(context).indexOf(CONST.PEER_REVIEW_WORKFLOW_PATH) > -1;
-}
-
-function isPassing(context) {
-    if (context.type === 'CheckRun') {
-        return context.status === 'COMPLETED' && _.contains(PASSING_CHECK_RUN_CONCLUSIONS, context.conclusion);
-    }
-    return context.type === 'StatusContext' && context.state === 'SUCCESS';
-}
-
-function hasFailed(context) {
-    if (context.type === 'CheckRun') {
-        return context.status === 'COMPLETED' && _.contains(FAILED_CHECK_RUN_CONCLUSIONS, context.conclusion);
-    }
-    return context.type === 'StatusContext' && (context.state === 'FAILURE' || context.state === 'ERROR');
-}
-
-function hasReported(context) {
-    if (context.type === 'CheckRun') {
-        return context.status === 'COMPLETED';
-    }
-    return context.type === 'StatusContext' && !_.contains(UNREPORTED_STATUS_CONTEXT_STATES, context.state);
-}
-
-/**
- * Whether a commit that GitHub shows as failing only fails because of checks we ignore.
- *
- * @param {Array<Object>} contexts
- * @returns {Boolean}
- */
-function onlyIgnoredChecksAreFailing(contexts) {
-    const [ignoredContexts, contextsThatCount] = _.partition(contexts, isIgnoredCheck);
-
-    // An ignored check has to be the thing making GitHub show the commit as failed. Requiring that is also
-    // what keeps a response we couldn't read from turning a genuinely failing commit green.
-    if (!_.any(ignoredContexts, hasFailed)) {
-        return false;
-    }
-
-    return _.all(contextsThatCount, isPassing);
-}
-
-// Coalesce bursts of mutations into a single scan per animation frame so that the rapid
-// stream of DOM changes during page load doesn't trigger a scan per node.
-function scheduleScan() {
-    if (scanScheduled) {
-        return;
-    }
-    scanScheduled = true;
-    requestAnimationFrame(() => {
-        scanScheduled = false;
-
-        // eslint-disable-next-line no-use-before-define
-        scan();
-    });
-}
-
-/**
- * Whether a commit should be shown as passing, or null while there is no verdict worth acting on. Requests
- * one in the background when the one we have has expired.
- *
- * @param {String} owner
- * @param {String} repo
- * @param {String} sha
- * @returns {Boolean|null}
- */
-function getVerdict(owner, repo, sha) {
-    const key = `${owner}/${repo}/${sha}`;
-    const verdict = verdicts[key];
-
-    if (verdict && (verdict.isFinal || (Date.now() - verdict.fetchedAt) <= VERDICT_LIFETIME_MS)) {
-        return verdict.shouldShowAsPassing;
-    }
-
-    if (!requestsInFlight[key] && _.size(requestsInFlight) < MAX_CONCURRENT_REQUESTS) {
-        requestsInFlight[key] = true;
-        API.getStatusCheckRollup(owner, repo, sha)
-            .then((contexts) => {
-                const shouldShowAsPassing = onlyIgnoredChecksAreFailing(contexts);
-                verdicts[key] = {
-                    shouldShowAsPassing,
-
-                    // A commit that is failing with every check reported can't change without something
-                    // being re-run, so that verdict is worth keeping and a PR full of failing commits
-                    // stops asking about them. Everything else expires, including a commit still waiting
-                    // on checks, which is the usual state of one being worked on.
-                    isFinal: !shouldShowAsPassing && contexts.length > 0 && _.all(contexts, hasReported),
-                    fetchedAt: Date.now(),
-                };
-            })
-            .catch((error) => {
-                console.error('Error fetching check statuses for commit', sha, error);
-
-                // Recording the failure is what stops a bad token or a rate limit from turning every scan
-                // into another request. A null verdict leaves the indicator as GitHub rendered it.
-                verdicts[key] = {shouldShowAsPassing: null, isFinal: false, fetchedAt: Date.now()};
-            })
-            .finally(() => {
-                delete requestsInFlight[key];
-
-                // The page is usually done changing by the time a verdict lands, so nothing else would
-                // scan again. This also picks up commits that couldn't get a request slot earlier.
-                scheduleScan();
-            });
-    }
-
-    return null;
-}
 
 function replaceIcon(element, currentClass, newClass, iconPath) {
     const icon = element.querySelector(`svg.${currentClass}`);
@@ -263,7 +113,7 @@ function findIndicators() {
 function scan() {
     _.each(findIndicators(), (indicator) => {
         const isRewritten = indicator.element.hasAttribute(REWRITTEN_ATTRIBUTE);
-        const verdict = getVerdict(indicator.owner, indicator.repo, indicator.sha);
+        const verdict = CheckStatusVerdicts.getVerdict(indicator.owner, indicator.repo, indicator.sha);
 
         // A null verdict means we have nothing to say yet, so whatever is on screen stays.
         if (verdict === true && !isRewritten) {
@@ -274,11 +124,25 @@ function scan() {
     });
 }
 
+// Coalesce bursts of mutations into a single scan per animation frame so that the rapid
+// stream of DOM changes during page load doesn't trigger a scan per node.
+function scheduleScan() {
+    if (scanScheduled) {
+        return;
+    }
+    scanScheduled = true;
+    requestAnimationFrame(() => {
+        scanScheduled = false;
+        scan();
+    });
+}
+
 function start() {
     if (observer) {
         return;
     }
 
+    CheckStatusVerdicts.onVerdictSettled(scheduleScan);
     scheduleScan();
 
     // GitHub re-renders these indicators as checks report in, which puts the red X back.

--- a/src/js/lib/pages/github/pr.js
+++ b/src/js/lib/pages/github/pr.js
@@ -4,6 +4,7 @@ import ToggleTimestamps from '../../../module/ToggleTimestamps/ToggleTimestamps'
 import ToggleAutoLoadMore from '../../../module/ToggleAutoLoadMore/ToggleAutoLoadMore';
 import * as autoLoadMoreComments from '../../autoLoadMoreComments';
 import * as commitCheckStatuses from '../../commitCheckStatuses';
+import * as prFavicon from '../../prFavicon';
 
 /**
  * Replaces all `- [ ]` with `- [x]` in textareas with specific names
@@ -146,6 +147,7 @@ export default function () {
 
         autoLoadMoreComments.initAutoLoadMoreComments();
         commitCheckStatuses.initCommitCheckStatuses();
+        prFavicon.initPrFavicon();
     };
 
     return PrPage;

--- a/src/js/lib/prFavicon.js
+++ b/src/js/lib/prFavicon.js
@@ -1,0 +1,164 @@
+import _ from 'underscore';
+import ReactNativeOnyx from 'react-native-onyx';
+import * as API from './api';
+import * as Preferences from './actions/Preferences';
+import * as CheckStatusVerdicts from './checkStatusVerdicts';
+import ONYXKEYS from '../ONYXKEYS';
+
+// GitHub serves its own favicon for each state and swaps the link between them as a PR's checks report in,
+// so this only has to point the link at the asset GitHub already has. Drawing a replacement icon instead
+// would mean fetching, decoding and re-encoding it, and a tab falls back to the browser's default globe if
+// any step of that chain fails.
+const FAVICON_LINK_SELECTOR = 'link.js-site-favicon';
+const FAILURE_FAVICON_REGEX = /-failure(\.\w+)(\?.*)?$/;
+
+// Holds the href GitHub had set, so it can be put back exactly rather than rebuilt.
+const REWRITTEN_ATTRIBUTE = 'data-k2-original-favicon';
+
+const PULL_REQUEST_PATH_REGEX = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/;
+
+// The favicon reports on the pull request as a whole, which is the state of its head commit. That commit
+// changes when the author pushes, so this is worth re-reading periodically.
+const HEAD_REF_OID_LIFETIME_MS = 60000;
+
+const headRefOids = {};
+const requestsInFlight = {};
+
+let observer = null;
+let updateScheduled = false;
+let preferenceSubscribed = false;
+
+// Coalesce the burst of head changes GitHub makes on load into a single update.
+function scheduleUpdate() {
+    if (updateScheduled) {
+        return;
+    }
+    updateScheduled = true;
+    requestAnimationFrame(() => {
+        updateScheduled = false;
+
+        // eslint-disable-next-line no-use-before-define
+        update();
+    });
+}
+
+/**
+ * The commit at the head of the pull request being viewed, or null until we know it. Requests it in the
+ * background when what we have has expired.
+ *
+ * @param {String} owner
+ * @param {String} repo
+ * @param {String} pullRequestNumber
+ * @returns {String|null}
+ */
+function getHeadRefOid(owner, repo, pullRequestNumber) {
+    const key = `${owner}/${repo}/${pullRequestNumber}`;
+    const cached = headRefOids[key];
+
+    if (!cached || (Date.now() - cached.fetchedAt) > HEAD_REF_OID_LIFETIME_MS) {
+        if (!requestsInFlight[key]) {
+            requestsInFlight[key] = true;
+            API.getPullRequestHeadRefOid(owner, repo, Number(pullRequestNumber))
+                .then((oid) => {
+                    headRefOids[key] = {oid, fetchedAt: Date.now()};
+                })
+                .catch((error) => {
+                    console.error('Error fetching the head commit of pull request', key, error);
+
+                    // Recording the failure is what stops a bad token or a rate limit from turning every
+                    // pass into another request.
+                    headRefOids[key] = {oid: null, fetchedAt: Date.now()};
+                })
+                .finally(() => {
+                    delete requestsInFlight[key];
+                    scheduleUpdate();
+                });
+        }
+    }
+
+    // A head commit that has moved on is still the right one to ask about while its replacement is on the
+    // way, because the checks it is being replaced by haven't reported yet either.
+    return cached ? cached.oid : null;
+}
+
+function update() {
+    const links = document.querySelectorAll(FAVICON_LINK_SELECTOR);
+    const matches = window.location.pathname.match(PULL_REQUEST_PATH_REGEX);
+
+    if (!matches) {
+        // GitHub owns the favicon everywhere else, so forget the pull request we were on rather than
+        // putting its icon back over whatever it has set since.
+        _.each(links, link => link.removeAttribute(REWRITTEN_ATTRIBUTE));
+        return;
+    }
+
+    const [, owner, repo, pullRequestNumber] = matches;
+    const headRefOid = getHeadRefOid(owner, repo, pullRequestNumber);
+    const verdict = headRefOid ? CheckStatusVerdicts.getVerdict(owner, repo, headRefOid) : null;
+
+    _.each(links, (link) => {
+        const originalHref = link.getAttribute(REWRITTEN_ATTRIBUTE);
+        const href = link.getAttribute('href') || '';
+
+        // A null verdict means we have nothing to say yet, so whatever GitHub has set stays.
+        if (verdict === true && FAILURE_FAVICON_REGEX.test(href)) {
+            link.setAttribute(REWRITTEN_ATTRIBUTE, href);
+            link.setAttribute('href', href.replace(FAILURE_FAVICON_REGEX, '-success$1$2'));
+        } else if (verdict === false && originalHref) {
+            link.setAttribute('href', originalHref);
+            link.removeAttribute(REWRITTEN_ATTRIBUTE);
+        }
+    });
+}
+
+function start() {
+    if (observer) {
+        return;
+    }
+
+    CheckStatusVerdicts.onVerdictSettled(scheduleUpdate);
+    scheduleUpdate();
+
+    // GitHub sets the favicon after the page has loaded and again whenever the checks it is reporting on
+    // change, either of which puts the red X back.
+    observer = new MutationObserver(scheduleUpdate);
+    observer.observe(document.head, {
+        childList: true, subtree: true, attributes: true, attributeFilter: ['href'],
+    });
+}
+
+/**
+ * Shows the tab's favicon as passing when the only check holding the pull request back is one we ignore,
+ * so a tab left open while iterating still says whether the tests are passing.
+ */
+function initPrFavicon() {
+    // Every lookup needs the API, and an unauthenticated Octokit gets cached for the life of the page, so
+    // nothing here may touch it until the token the user entered on the dashboard has loaded out of Onyx.
+    // That includes the pass below: one early call poisons every request the extension makes afterwards.
+    if (Preferences.getGitHubToken()) {
+        start();
+
+        // GitHub swaps page content without reloading, so a pull request opened from another page needs
+        // another pass even though the observer is already attached.
+        scheduleUpdate();
+        return;
+    }
+
+    if (preferenceSubscribed) {
+        return;
+    }
+    preferenceSubscribed = true;
+
+    ReactNativeOnyx.connect({
+        key: ONYXKEYS.PREFERENCES,
+        callback: () => {
+            if (!Preferences.getGitHubToken()) {
+                return;
+            }
+            start();
+        },
+    });
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export {initPrFavicon};


### PR DESCRIPTION
### Fixed Issues
For https://github.com/Expensify/Expensify/issues/668743

### Problem

[#368](https://github.com/Expensify/k2-extension/pull/368) fixed the per-commit indicators in a PR's history, but the tab's favicon has the same problem. GitHub shows a red X in the favicon while a PR's checks are failing, and since the org-wide ruleset started triggering [verifyPeerReview.yml](https://github.com/Expensify/GitHub-Actions/blob/main/.github/workflows/verifyPeerReview.yml), that X is there from the moment the PR opens until someone reviews it

### Solution
Point the favicon link at the passing icon **GitHub already serves** when the only check holding the PR back is one we ignore.

That last part matters. GitHub keeps a favicon per state (`favicon-failure`, `favicon-success`, `favicon-pending`, in both `.svg` and `.png`) and swaps its own `link.js-site-favicon` between them — the SVG link even carries `data-base-href` for exactly that. So this is a one-attribute change to a URL GitHub is already serving.

- `src/js/lib/checkStatusVerdicts.js` (new) — the verdict cache and the classification logic, moved out of `commitCheckStatuses.js`. The favicon and the commit rows now share one cache and, more to the point, one decision about what counts as failing. Duplicating that would mean two places to get a wrong green wrong.
- `src/js/lib/prFavicon.js` (new) — resolves the PR's head commit, asks for its verdict, and swaps the link. Stores the href GitHub had set so it can be put back exactly rather than rebuilt.
- `src/js/lib/api.js` — `getPullRequestHeadRefOid()`, since the favicon reports on the PR as a whole, which is the state of its head commit.

Carried over from [#368](https://github.com/Expensify/k2-extension/pull/368): a null verdict leaves whatever GitHub set alone, a verdict of `false` puts our change back, and the head SHA is re-read after 60s so a push doesn't leave us reporting on the wrong commit. Navigating off the PR drops our marker rather than holding a stale icon over whatever GitHub sets next.

One bug fix worth calling out: the first version ran a pass at init before the token had loaded out of Onyx. `getOctokit()` memoises for the life of the page, so that single early call cached an unauthenticated client and made **every** subsequent GraphQL request 403. The init path now touches nothing until the token is there.

### Tests

GitHub only swaps in its status favicon for a signed-in session, so these set the failing favicon GitHub would have set and check what the extension does with it. Everything else — the verdict, the head commit lookup, the API — is real.

1. Run `npm run build`, then load the `dist/` folder as an unpacked extension.
2. Open https://github.com/Expensify/App/pull/98020, whose head commit fails `Check independent approval` and nothing else.
3. Confirm the tab's favicon shows a green check once the checks have reported.
4. Open https://github.com/Expensify/App/pull/98015, whose head commit fails `checklist` as well.
5. Confirm the tab's favicon still shows a red X.
6. Navigate from the PR in step 2 to any non-PR page and confirm the favicon is whatever GitHub sets, not a leftover green check.